### PR TITLE
Feat/endpoint submissao

### DIFF
--- a/backend/app/api/laws.py
+++ b/backend/app/api/laws.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, status
+
+from app.db.client import db
+from app.models.law import LawResponse, LawSubmissionRequest
+
+router = APIRouter(prefix="/laws", tags=["laws"])
+
+
+@router.post("", response_model=LawResponse, status_code=status.HTTP_201_CREATED)
+async def submit_law(law: LawSubmissionRequest):
+    """Cria uma lei submetida pelo usuario para avaliacao posterior."""
+    data = law.model_dump(exclude_none=True)
+    data["sourceType"] = "USER_UPLOAD"
+
+    return await db.law.create(data=data)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.api import health
+from app.api import health, laws
 from app.db.client import db
 
 app = FastAPI()
@@ -31,3 +31,4 @@ async def shutdown():
 
 
 app.include_router(health.router)
+app.include_router(laws.router)

--- a/backend/app/models/law.py
+++ b/backend/app/models/law.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LawSubmissionRequest(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    title: str = Field(..., min_length=1)
+    description: str | None = None
+    text: str = Field(..., min_length=1)
+    sourceUrl: str | None = None
+    jurisdiction: str | None = None
+    lawNumber: str | None = None
+    publicationDate: datetime | None = None
+    uploadedByUserId: str | None = None
+    isPublic: bool = False
+    
+
+class LawResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    title: str
+    description: str | None
+    text: str
+    sourceType: str
+    sourceUrl: str | None
+    jurisdiction: str | None
+    lawNumber: str | None
+    publicationDate: datetime | None
+    uploadedByUserId: str | None
+    isPublic: bool
+    createdAt: datetime
+    updatedAt: datetime

--- a/backend/tests/test_laws.py
+++ b/backend/tests/test_laws.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.api import laws
+from app.main import app
+
+client = TestClient(app)
+
+
+class FakeLawDelegate:
+    def __init__(self):
+        self.created_data = None
+
+    async def create(self, data):
+        """Simula a criacao de uma lei pelo delegate do Prisma."""
+        self.created_data = data
+        now = datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc)
+
+        return SimpleNamespace(
+            id="law-123",
+            createdAt=now,
+            updatedAt=now,
+            description=None,
+            sourceUrl=None,
+            jurisdiction=None,
+            lawNumber=None,
+            publicationDate=None,
+            uploadedByUserId=None,
+            **data,
+        )
+
+
+def test_submit_law_cria_lei_como_user_upload(monkeypatch):
+    """Verifica que a submissao salva a lei como upload do usuario."""
+    fake_law_delegate = FakeLawDelegate()
+    monkeypatch.setattr(laws, "db", SimpleNamespace(law=fake_law_delegate))
+
+    response = client.post(
+        "/laws",
+        json={
+            "title": "Projeto de Lei sobre transparencia",
+            "text": "Art. 1 Esta lei estabelece regras de transparencia publica.",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fake_law_delegate.created_data == {
+        "title": "Projeto de Lei sobre transparencia",
+        "text": "Art. 1 Esta lei estabelece regras de transparencia publica.",
+        "isPublic": False,
+        "sourceType": "USER_UPLOAD",
+    }
+    assert response.json()["id"] == "law-123"
+    assert response.json()["sourceType"] == "USER_UPLOAD"
+
+
+def test_submit_law_exige_titulo_e_texto():
+    """Verifica que titulo e texto vazios retornam erro de validacao."""
+    response = client.post("/laws", json={"title": "", "text": ""})
+
+    assert response.status_code == 422


### PR DESCRIPTION
## 📝 Descrição

Implementa o endpoint `POST /laws` para permitir que o usuário submeta uma lei/texto legislativo para avaliação futura de qualidade.

A alteração adiciona:
- Rota `POST /laws`;
- Schemas Pydantic para entrada e resposta da submissão;
- Persistência da lei usando Prisma;
- Registro automático da lei com `sourceType = USER_UPLOAD`;
- Testes cobrindo criação da lei e validação de campos obrigatórios;
- Docstrings nas funções adicionadas.

## 🏷️ Tipo de alteração

- [x] ✨ `feat:` Nova funcionalidade
- [ ] 🐛 `bugfix:` Correção de um erro
- [ ] ♻️ `refactor:` Refatoração de código (não altera as funcionalidades)
- [ ] 📚 `docs:` Atualização na documentação
- [ ] 🔧 `chore:` Tarefas de manutenção (dependências, configurações, etc.)

## ✅ Checklist de Revisão

- [x] O meu código segue os padrões do nosso Guia Definitivo.
- [x] Realizei uma auto-revisão detalhada do meu próprio código.
- [x] Os meus commits são atômicos e as mensagens seguem o padrão *Conventional Commits*.
- [x] O código não gera novos conflitos de merge (verifiquei a branch base).
- [x] A alteração não introduz novos avisos (warnings) ou erros no terminal.

## 🧪 Testes

- [x] Criei/atualizei testes para esta funcionalidade (se aplicável).
- [x] Testei a funcionalidade localmente e tudo está funcionando perfeitamente.

## 🖼️ Capturas de tela ou Vídeos (Se aplicável)

Não aplicável.