### PR TITLE
Feat/crud usuario

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ POSTGRES_PASSWORD=troque_esta_senha
 POSTGRES_DB=app_db
 DATABASE_URL=postgresql://postgres:troque_esta_senha@db:5432/app_db
 ENVIRONMENT=development
+AUTH_SECRET_KEY=troque_esta_chave_secreta
+ACCESS_TOKEN_EXPIRE_MINUTES=60

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,7 @@ ENV HOME=/home/appuser
 COPY --chown=appuser:appgroup . .
 
 RUN prisma generate --schema=prisma/schema.prisma \
-    && chown -R appuser:appgroup /home/appuser /app
+    && chown -R appuser:appgroup /home/appuser /app /usr/local/lib/python3.12/site-packages/prisma
 
 USER appuser
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 
 from app.db.client import db
-from app.models.user import AuthResponse, UserCreateRequest, UserLoginRequest
+from app.models.user import AuthResponse, UserLoginRequest, UserRegisterRequest
 from app.services.security import create_access_token, hash_password, verify_password
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
     response_model=AuthResponse,
     status_code=status.HTTP_201_CREATED,
 )
-async def register(user: UserCreateRequest):
+async def register(user: UserRegisterRequest):
     """Cadastra um usuario e retorna um token de acesso."""
     existing_user = await db.user.find_unique(where={"email": user.email})
     if existing_user:
@@ -22,6 +22,7 @@ async def register(user: UserCreateRequest):
         )
 
     data = user.model_dump(exclude={"password"})
+    data["role"] = "COMMON"
     data["passwordHash"] = hash_password(user.password)
     created_user = await db.user.create(data=data)
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, HTTPException, status
+
+from app.db.client import db
+from app.models.user import AuthResponse, UserCreateRequest, UserLoginRequest
+from app.services.security import create_access_token, hash_password, verify_password
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post(
+    "/register",
+    response_model=AuthResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def register(user: UserCreateRequest):
+    """Cadastra um usuario e retorna um token de acesso."""
+    existing_user = await db.user.find_unique(where={"email": user.email})
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Ja existe um usuario com este e-mail.",
+        )
+
+    data = user.model_dump(exclude={"password"})
+    data["passwordHash"] = hash_password(user.password)
+    created_user = await db.user.create(data=data)
+
+    return {
+        "accessToken": create_access_token(created_user),
+        "user": created_user,
+    }
+
+
+@router.post("/login", response_model=AuthResponse)
+async def login(credentials: UserLoginRequest):
+    """Autentica um usuario com e-mail e senha."""
+    user = await db.user.find_unique(where={"email": credentials.email})
+    if not user or not verify_password(credentials.password, user.passwordHash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Email ou senha invalidos.",
+        )
+
+    return {
+        "accessToken": create_access_token(user),
+        "user": user,
+    }

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,0 +1,54 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.db.client import db
+from app.services.security import decode_access_token
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+):
+    if not credentials or credentials.scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token de autenticacao nao informado.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    payload = decode_access_token(credentials.credentials)
+    if not payload:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token de autenticacao invalido ou expirado.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user_id = payload.get("sub")
+    if not isinstance(user_id, str):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token de autenticacao invalido.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user = await db.user.find_unique(where={"id": user_id})
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Usuario autenticado nao encontrado.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return user
+
+
+async def require_admin_user(current_user=Depends(get_current_user)):
+    if current_user.role != "ADMIN":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Apenas administradores podem acessar este recurso.",
+        )
+
+    return current_user

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,10 +1,15 @@
-from fastapi import APIRouter, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 
+from app.api.dependencies import require_admin_user
 from app.db.client import db
 from app.models.user import UserCreateRequest, UserResponse, UserUpdateRequest
 from app.services.security import hash_password
 
-router = APIRouter(prefix="/users", tags=["users"])
+router = APIRouter(
+    prefix="/users",
+    tags=["users"],
+    dependencies=[Depends(require_admin_user)],
+)
 
 
 @router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter, HTTPException, Response, status
+
+from app.db.client import db
+from app.models.user import UserCreateRequest, UserResponse, UserUpdateRequest
+from app.services.security import hash_password
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+async def create_user(user: UserCreateRequest):
+    """Cria um usuario com senha hasheada."""
+    existing_user = await db.user.find_unique(where={"email": user.email})
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Ja existe um usuario com este e-mail.",
+        )
+
+    data = user.model_dump(exclude={"password"})
+    data["passwordHash"] = hash_password(user.password)
+
+    return await db.user.create(data=data)
+
+
+@router.get("", response_model=list[UserResponse])
+async def list_users():
+    """Lista todos os usuarios."""
+    return await db.user.find_many()
+
+
+@router.get("/{user_id}", response_model=UserResponse)
+async def get_user(user_id: str):
+    """Busca um usuario pelo id."""
+    user = await db.user.find_unique(where={"id": user_id})
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Usuario nao encontrado.",
+        )
+
+    return user
+
+
+@router.patch("/{user_id}", response_model=UserResponse)
+async def update_user(user_id: str, user: UserUpdateRequest):
+    """Atualiza parcialmente um usuario."""
+    existing_user = await db.user.find_unique(where={"id": user_id})
+    if not existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Usuario nao encontrado.",
+        )
+
+    data = user.model_dump(exclude_unset=True)
+    if not data:
+        return existing_user
+
+    if "email" in data:
+        user_with_email = await db.user.find_unique(where={"email": data["email"]})
+        if user_with_email and user_with_email.id != user_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Ja existe um usuario com este e-mail.",
+            )
+
+    if "password" in data:
+        data["passwordHash"] = hash_password(data.pop("password"))
+
+    return await db.user.update(where={"id": user_id}, data=data)
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user(user_id: str):
+    """Remove um usuario pelo id."""
+    existing_user = await db.user.find_unique(where={"id": user_id})
+    if not existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Usuario nao encontrado.",
+        )
+
+    await db.user.delete(where={"id": user_id})
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.api import health, laws
+from app.api import auth, health, laws, users
 from app.db.client import db
 
 app = FastAPI()
@@ -31,4 +31,6 @@ async def shutdown():
 
 
 app.include_router(health.router)
+app.include_router(auth.router)
 app.include_router(laws.router)
+app.include_router(users.router)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+UserRole = Literal["COMMON", "ADMIN"]
+
+
+class UserCreateRequest(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    name: str = Field(..., min_length=1)
+    email: EmailStr
+    password: str = Field(..., min_length=8)
+    role: UserRole = "COMMON"
+
+
+class UserUpdateRequest(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    name: str | None = Field(default=None, min_length=1)
+    email: EmailStr | None = None
+    password: str | None = Field(default=None, min_length=8)
+    role: UserRole | None = None
+
+
+class UserLoginRequest(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    email: EmailStr
+    password: str = Field(..., min_length=1)
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    name: str
+    email: EmailStr
+    role: str
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class AuthResponse(BaseModel):
+    accessToken: str
+    tokenType: str = "bearer"
+    user: UserResponse

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,13 +1,26 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
-
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 UserRole = Literal["COMMON", "ADMIN"]
 
 
-class UserCreateRequest(BaseModel):
+class EmailNormalizeMixin(BaseModel):
+    @field_validator("email", check_fields=False)
+    @classmethod
+    def normalize_email(cls, email: str) -> str:
+        return email.lower()
+
+
+class UserCreateRequest(EmailNormalizeMixin):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     name: str = Field(..., min_length=1)
@@ -16,7 +29,7 @@ class UserCreateRequest(BaseModel):
     role: UserRole = "COMMON"
 
 
-class UserUpdateRequest(BaseModel):
+class UserUpdateRequest(EmailNormalizeMixin):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     name: str | None = Field(default=None, min_length=1)
@@ -24,8 +37,19 @@ class UserUpdateRequest(BaseModel):
     password: str | None = Field(default=None, min_length=8)
     role: UserRole | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def reject_null_fields(cls, data):
+        if isinstance(data, dict):
+            null_fields = [field for field, value in data.items() if value is None]
+            if null_fields:
+                fields = ", ".join(sorted(null_fields))
+                raise ValueError(f"Campos nao podem ser nulos: {fields}.")
 
-class UserLoginRequest(BaseModel):
+        return data
+
+
+class UserLoginRequest(EmailNormalizeMixin):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     email: EmailStr

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -20,12 +20,15 @@ class EmailNormalizeMixin(BaseModel):
         return email.lower()
 
 
-class UserCreateRequest(EmailNormalizeMixin):
+class UserRegisterRequest(EmailNormalizeMixin):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     name: str = Field(..., min_length=1)
     email: EmailStr
     password: str = Field(..., min_length=8)
+
+
+class UserCreateRequest(UserRegisterRequest):
     role: UserRole = "COMMON"
 
 

--- a/backend/app/services/security.py
+++ b/backend/app/services/security.py
@@ -49,6 +49,36 @@ def create_access_token(user) -> str:
     return f"{signing_input}.{_base64url_encode(signature)}"
 
 
+def decode_access_token(token: str) -> dict | None:
+    try:
+        encoded_header, encoded_payload, encoded_signature = token.split(".")
+        signing_input = f"{encoded_header}.{encoded_payload}"
+        expected_signature = hmac.new(
+            AUTH_SECRET_KEY.encode("utf-8"),
+            signing_input.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+        signature = _base64url_decode(encoded_signature)
+        if not hmac.compare_digest(signature, expected_signature):
+            return None
+
+        header = json.loads(_base64url_decode(encoded_header))
+        if header.get("alg") != "HS256":
+            return None
+
+        payload = json.loads(_base64url_decode(encoded_payload))
+        expires_at = payload.get("exp")
+        if not isinstance(expires_at, int):
+            return None
+
+        if datetime.now(timezone.utc).timestamp() >= expires_at:
+            return None
+
+        return payload
+    except (ValueError, json.JSONDecodeError):
+        return None
+
+
 def _base64url_encode_json(data: dict) -> str:
     json_bytes = json.dumps(data, separators=(",", ":")).encode("utf-8")
     return _base64url_encode(json_bytes)
@@ -56,3 +86,8 @@ def _base64url_encode_json(data: dict) -> str:
 
 def _base64url_encode(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _base64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(f"{data}{padding}")

--- a/backend/app/services/security.py
+++ b/backend/app/services/security.py
@@ -1,0 +1,58 @@
+import base64
+import hashlib
+import hmac
+import json
+import os
+from datetime import datetime, timedelta, timezone
+import bcrypt
+
+
+AUTH_SECRET_KEY = os.getenv("AUTH_SECRET_KEY", "dev-secret-change-me")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+
+
+def hash_password(password: str) -> str:
+    password_bytes = password.encode("utf-8")
+    return bcrypt.hashpw(password_bytes, bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    password_bytes = password.encode("utf-8")
+    hash_bytes = password_hash.encode("utf-8")
+    try:
+        return bcrypt.checkpw(password_bytes, hash_bytes)
+    except ValueError:
+        return False
+
+
+def create_access_token(user) -> str:
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        minutes=ACCESS_TOKEN_EXPIRE_MINUTES
+    )
+    payload = {
+        "sub": user.id,
+        "email": user.email,
+        "role": user.role,
+        "exp": int(expires_at.timestamp()),
+    }
+
+    header = {"alg": "HS256", "typ": "JWT"}
+    encoded_header = _base64url_encode_json(header)
+    encoded_payload = _base64url_encode_json(payload)
+    signing_input = f"{encoded_header}.{encoded_payload}"
+    signature = hmac.new(
+        AUTH_SECRET_KEY.encode("utf-8"),
+        signing_input.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+
+    return f"{signing_input}.{_base64url_encode(signature)}"
+
+
+def _base64url_encode_json(data: dict) -> str:
+    json_bytes = json.dumps(data, separators=(",", ":")).encode("utf-8")
+    return _base64url_encode(json_bytes)
+
+
+def _base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi[all]
+bcrypt
 prisma
 pydantic
 pydantic-settings

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,138 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.api import auth
+from app.main import app
+
+client = TestClient(app)
+
+
+def make_user(
+    user_id="user-123",
+    name="Maria Silva",
+    email="maria@example.com",
+    password_hash="hashed-senha-segura",
+    role="COMMON",
+):
+    now = datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc)
+
+    return SimpleNamespace(
+        id=user_id,
+        name=name,
+        email=email,
+        passwordHash=password_hash,
+        role=role,
+        createdAt=now,
+        updatedAt=now,
+    )
+
+
+class FakeUserDelegate:
+    def __init__(self, initial_users=None):
+        self.users_by_id = {}
+        self.created_data = None
+
+        for user in initial_users or []:
+            self.users_by_id[user.id] = user
+
+    async def create(self, data):
+        self.created_data = data
+        created_user = make_user(
+            user_id="user-created",
+            name=data["name"],
+            email=data["email"],
+            password_hash=data["passwordHash"],
+            role=data["role"],
+        )
+        self.users_by_id[created_user.id] = created_user
+
+        return created_user
+
+    async def find_unique(self, where):
+        if "email" in where:
+            return next(
+                (
+                    user
+                    for user in self.users_by_id.values()
+                    if user.email == where["email"]
+                ),
+                None,
+            )
+
+        return None
+
+
+def test_register_cadastra_usuario_com_senha_hasheada(monkeypatch):
+    fake_user_delegate = FakeUserDelegate()
+    monkeypatch.setattr(auth, "db", SimpleNamespace(user=fake_user_delegate))
+    monkeypatch.setattr(auth, "hash_password", lambda password: f"hashed-{password}")
+    monkeypatch.setattr(auth, "create_access_token", lambda user: f"token-{user.id}")
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "name": "Maria Silva",
+            "email": "maria@example.com",
+            "password": "senha-segura",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fake_user_delegate.created_data == {
+        "name": "Maria Silva",
+        "email": "maria@example.com",
+        "role": "COMMON",
+        "passwordHash": "hashed-senha-segura",
+    }
+    assert response.json()["accessToken"] == "token-user-created"
+    assert response.json()["tokenType"] == "bearer"
+    assert "passwordHash" not in response.json()["user"]
+
+
+def test_register_retorna_409_quando_email_ja_existe(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(auth, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "name": "Maria Silva",
+            "email": "maria@example.com",
+            "password": "senha-segura",
+        },
+    )
+
+    assert response.status_code == 409
+    assert fake_user_delegate.created_data is None
+
+
+def test_login_retorna_token_quando_credenciais_sao_validas(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(auth, "db", SimpleNamespace(user=fake_user_delegate))
+    monkeypatch.setattr(auth, "verify_password", lambda password, hash: True)
+    monkeypatch.setattr(auth, "create_access_token", lambda user: f"token-{user.id}")
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "maria@example.com", "password": "senha-segura"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["accessToken"] == "token-user-123"
+    assert response.json()["user"]["email"] == "maria@example.com"
+    assert "passwordHash" not in response.json()["user"]
+
+
+def test_login_retorna_401_quando_senha_e_invalida(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(auth, "db", SimpleNamespace(user=fake_user_delegate))
+    monkeypatch.setattr(auth, "verify_password", lambda password, hash: False)
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "maria@example.com", "password": "senha-incorreta"},
+    )
+
+    assert response.status_code == 401

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -108,6 +108,26 @@ def test_register_retorna_409_quando_email_ja_existe(monkeypatch):
     assert fake_user_delegate.created_data is None
 
 
+def test_register_normaliza_email_para_minusculas(monkeypatch):
+    fake_user_delegate = FakeUserDelegate()
+    monkeypatch.setattr(auth, "db", SimpleNamespace(user=fake_user_delegate))
+    monkeypatch.setattr(auth, "hash_password", lambda password: f"hashed-{password}")
+    monkeypatch.setattr(auth, "create_access_token", lambda user: f"token-{user.id}")
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "name": "Maria Silva",
+            "email": "MARIA@EXAMPLE.COM",
+            "password": "senha-segura",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fake_user_delegate.created_data["email"] == "maria@example.com"
+    assert response.json()["user"]["email"] == "maria@example.com"
+
+
 def test_login_retorna_token_quando_credenciais_sao_validas(monkeypatch):
     fake_user_delegate = FakeUserDelegate([make_user()])
     monkeypatch.setattr(auth, "db", SimpleNamespace(user=fake_user_delegate))

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -128,6 +128,27 @@ def test_register_normaliza_email_para_minusculas(monkeypatch):
     assert response.json()["user"]["email"] == "maria@example.com"
 
 
+def test_register_ignora_role_do_payload_publico(monkeypatch):
+    fake_user_delegate = FakeUserDelegate()
+    monkeypatch.setattr(auth, "db", SimpleNamespace(user=fake_user_delegate))
+    monkeypatch.setattr(auth, "hash_password", lambda password: f"hashed-{password}")
+    monkeypatch.setattr(auth, "create_access_token", lambda user: f"token-{user.id}")
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "name": "Maria Silva",
+            "email": "maria@example.com",
+            "password": "senha-segura",
+            "role": "ADMIN",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fake_user_delegate.created_data["role"] == "COMMON"
+    assert response.json()["user"]["role"] == "COMMON"
+
+
 def test_login_retorna_token_quando_credenciais_sao_validas(monkeypatch):
     fake_user_delegate = FakeUserDelegate([make_user()])
     monkeypatch.setattr(auth, "db", SimpleNamespace(user=fake_user_delegate))

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.api import users
@@ -91,6 +92,31 @@ class FakeUserDelegate:
     async def delete(self, where):
         self.deleted_where = where
         return self.users_by_id.pop(where["id"])
+
+
+@pytest.fixture(autouse=True)
+def admin_dependency_override():
+    app.dependency_overrides[users.require_admin_user] = lambda: make_user(role="ADMIN")
+    yield
+    app.dependency_overrides.pop(users.require_admin_user, None)
+
+
+def test_list_users_rejeita_requisicao_sem_token():
+    app.dependency_overrides.pop(users.require_admin_user, None)
+
+    response = client.get("/users")
+
+    assert response.status_code == 401
+
+
+def test_list_users_rejeita_usuario_sem_role_admin():
+    app.dependency_overrides[users.require_admin_user] = lambda: (_ for _ in ()).throw(
+        users.HTTPException(status_code=403, detail="Apenas administradores.")
+    )
+
+    response = client.get("/users")
+
+    assert response.status_code == 403
 
 
 def test_create_user_cria_usuario_e_nao_retorna_password_hash(monkeypatch):

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -137,6 +137,25 @@ def test_create_user_retorna_409_quando_email_ja_existe(monkeypatch):
     assert fake_user_delegate.created_data is None
 
 
+def test_create_user_normaliza_email_para_minusculas(monkeypatch):
+    fake_user_delegate = FakeUserDelegate()
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    monkeypatch.setattr(users, "hash_password", lambda password: f"hashed-{password}")
+
+    response = client.post(
+        "/users",
+        json={
+            "name": "Maria Silva",
+            "email": "MARIA@EXAMPLE.COM",
+            "password": "senha-segura",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fake_user_delegate.created_data["email"] == "maria@example.com"
+    assert response.json()["email"] == "maria@example.com"
+
+
 def test_list_users_retorna_usuarios_sem_password_hash(monkeypatch):
     fake_user_delegate = FakeUserDelegate([make_user()])
     monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
@@ -189,6 +208,27 @@ def test_update_user_retorna_409_quando_email_pertence_a_outro_usuario(monkeypat
     response = client.patch("/users/user-123", json={"email": "ana@example.com"})
 
     assert response.status_code == 409
+    assert fake_user_delegate.updated_data is None
+
+
+def test_update_user_normaliza_email_para_minusculas(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.patch("/users/user-123", json={"email": "MARIA@EXAMPLE.COM"})
+
+    assert response.status_code == 200
+    assert fake_user_delegate.updated_data == {"email": "maria@example.com"}
+    assert response.json()["email"] == "maria@example.com"
+
+
+def test_update_user_rejeita_campos_nulos(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.patch("/users/user-123", json={"password": None})
+
+    assert response.status_code == 422
     assert fake_user_delegate.updated_data is None
 
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,202 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.api import users
+from app.main import app
+
+client = TestClient(app)
+
+
+def make_user(
+    user_id="user-123",
+    name="Maria Silva",
+    email="maria@example.com",
+    password_hash="hash-seguro",
+    role="COMMON",
+):
+    now = datetime(2026, 5, 20, 12, 0, tzinfo=timezone.utc)
+
+    return SimpleNamespace(
+        id=user_id,
+        name=name,
+        email=email,
+        passwordHash=password_hash,
+        role=role,
+        createdAt=now,
+        updatedAt=now,
+    )
+
+
+class FakeUserDelegate:
+    def __init__(self, initial_users=None):
+        self.users_by_id = {}
+        self.created_data = None
+        self.updated_where = None
+        self.updated_data = None
+        self.deleted_where = None
+
+        for user in initial_users or []:
+            self.users_by_id[user.id] = user
+
+    async def create(self, data):
+        self.created_data = data
+        created_user = make_user(
+            user_id="user-created",
+            name=data["name"],
+            email=data["email"],
+            password_hash=data["passwordHash"],
+            role=data["role"],
+        )
+        self.users_by_id[created_user.id] = created_user
+
+        return created_user
+
+    async def find_unique(self, where):
+        if "id" in where:
+            return self.users_by_id.get(where["id"])
+
+        if "email" in where:
+            return next(
+                (
+                    user
+                    for user in self.users_by_id.values()
+                    if user.email == where["email"]
+                ),
+                None,
+            )
+
+        return None
+
+    async def find_many(self):
+        return list(self.users_by_id.values())
+
+    async def update(self, where, data):
+        self.updated_where = where
+        self.updated_data = data
+        current_user = self.users_by_id[where["id"]]
+
+        updated_user = make_user(
+            user_id=current_user.id,
+            name=data.get("name", current_user.name),
+            email=data.get("email", current_user.email),
+            password_hash=data.get("passwordHash", current_user.passwordHash),
+            role=data.get("role", current_user.role),
+        )
+        self.users_by_id[updated_user.id] = updated_user
+
+        return updated_user
+
+    async def delete(self, where):
+        self.deleted_where = where
+        return self.users_by_id.pop(where["id"])
+
+
+def test_create_user_cria_usuario_e_nao_retorna_password_hash(monkeypatch):
+    fake_user_delegate = FakeUserDelegate()
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    monkeypatch.setattr(users, "hash_password", lambda password: f"hashed-{password}")
+
+    response = client.post(
+        "/users",
+        json={
+            "name": "Maria Silva",
+            "email": "maria@example.com",
+            "password": "senha-segura",
+            "role": "ADMIN",
+        },
+    )
+
+    assert response.status_code == 201
+    assert fake_user_delegate.created_data == {
+        "name": "Maria Silva",
+        "email": "maria@example.com",
+        "passwordHash": "hashed-senha-segura",
+        "role": "ADMIN",
+    }
+    assert response.json()["id"] == "user-created"
+    assert "passwordHash" not in response.json()
+
+
+def test_create_user_retorna_409_quando_email_ja_existe(monkeypatch):
+    existing_user = make_user(email="maria@example.com")
+    fake_user_delegate = FakeUserDelegate([existing_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.post(
+        "/users",
+        json={
+            "name": "Maria Silva",
+            "email": "maria@example.com",
+            "password": "senha-segura",
+        },
+    )
+
+    assert response.status_code == 409
+    assert fake_user_delegate.created_data is None
+
+
+def test_list_users_retorna_usuarios_sem_password_hash(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.get("/users")
+
+    assert response.status_code == 200
+    assert response.json()[0]["email"] == "maria@example.com"
+    assert "passwordHash" not in response.json()[0]
+
+
+def test_get_user_retorna_404_quando_nao_encontra(monkeypatch):
+    fake_user_delegate = FakeUserDelegate()
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.get("/users/user-inexistente")
+
+    assert response.status_code == 404
+
+
+def test_update_user_atualiza_somente_campos_enviados(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.patch("/users/user-123", json={"name": "Maria Souza"})
+
+    assert response.status_code == 200
+    assert fake_user_delegate.updated_where == {"id": "user-123"}
+    assert fake_user_delegate.updated_data == {"name": "Maria Souza"}
+    assert response.json()["name"] == "Maria Souza"
+
+
+def test_update_user_hasheia_senha_antes_de_atualizar(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    monkeypatch.setattr(users, "hash_password", lambda password: f"hashed-{password}")
+
+    response = client.patch("/users/user-123", json={"password": "nova-senha"})
+
+    assert response.status_code == 200
+    assert fake_user_delegate.updated_data == {"passwordHash": "hashed-nova-senha"}
+
+
+def test_update_user_retorna_409_quando_email_pertence_a_outro_usuario(monkeypatch):
+    current_user = make_user(user_id="user-123", email="maria@example.com")
+    another_user = make_user(user_id="user-456", email="ana@example.com")
+    fake_user_delegate = FakeUserDelegate([current_user, another_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.patch("/users/user-123", json={"email": "ana@example.com"})
+
+    assert response.status_code == 409
+    assert fake_user_delegate.updated_data is None
+
+
+def test_delete_user_remove_usuario(monkeypatch):
+    fake_user_delegate = FakeUserDelegate([make_user()])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+
+    response = client.delete("/users/user-123")
+
+    assert response.status_code == 204
+    assert fake_user_delegate.deleted_where == {"id": "user-123"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     restart: unless-stopped
     ports:
       - "8000:8000"
+    env_file:
+      - .env
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-app_db}?schema=public
     depends_on:


### PR DESCRIPTION
## 📝 Descrição
Esta PR adiciona o CRUD de usuários e os endpoints de autenticação no backend.

Principais mudanças:
- Criação dos endpoints `/users` para criar, listar, buscar, atualizar parcialmente e remover usuários.
- Criação dos endpoints `/auth/register` e `/auth/login`.
- Hash de senhas com `bcrypt`.
- Geração de token de acesso com expiração configurável.
- Schemas Pydantic para criação, atualização, login e resposta de usuário.
- Remoção de `passwordHash` das respostas da API.
- Validação de e-mail e senha.
- Normalização de e-mails para minúsculas.
- Rejeição de campos `null` no PATCH de usuário.
- Tratamento de erros para usuário inexistente, e-mail duplicado e credenciais inválidas.
- Registro das novas rotas no `main.py`.
- Inclusão das variáveis `AUTH_SECRET_KEY` e `ACCESS_TOKEN_EXPIRE_MINUTES` no `.env.example`.
- Configuração do `docker-compose.yml` para carregar variáveis via `.env`.
- Inclusão da dependência `bcrypt`.
- Criação de testes para autenticação e CRUD de usuário.

## 🏷️ Tipo de alteração
- [x] ✨ `feat:` Nova funcionalidade
- [ ] 🐛 `bugfix:` Correção de um erro
- [ ] ♻️ `refactor:` Refatoração de código (não altera as funcionalidades)
- [ ] 📚 `docs:` Atualização na documentação
- [ ] 🔧 `chore:` Tarefas de manutenção (dependências, configurações, etc.)

## ✅ Checklist de Revisão
- [x] O meu código segue os padrões do nosso Guia Definitivo.
- [x] Realizei uma auto-revisão detalhada do meu próprio código.
- [x] Os meus commits são atômicos e as mensagens seguem o padrão *Conventional Commits*.
- [x] O código não gera novos conflitos de merge (verifiquei a branch base).
- [x] A alteração não introduz novos avisos (warnings) ou erros no terminal.

## 🧪 Testes
- [x] Criei/atualizei testes para esta funcionalidade (se aplicável).
- [x] Testei a funcionalidade localmente e tudo está funcionando perfeitamente.

## 🖼️ Capturas de tela ou Vídeos (Se aplicável)
Não aplicável