### PR TITLE
feat: adiciona tabela de analysis 

### DIFF
--- a/backend/app/models/analysis.py
+++ b/backend/app/models/analysis.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AnalysisCreateRequest(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    lawId: str = Field(..., min_length=1)
+    score: float = Field(..., ge=0, le=1)
+    metrics: dict[str, Any]
+    warnings: list[dict[str, Any]]
+    modelVersion: str = Field(..., min_length=1)
+    cached: bool = False
+
+
+class AnalysisResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    lawId: str
+    score: float
+    metrics: dict[str, Any]
+    warnings: list[dict[str, Any]]
+    modelVersion: str
+    cached: bool
+    createdAt: datetime

--- a/backend/prisma/migrations/20260619140510_add_analysis_table/migration.sql
+++ b/backend/prisma/migrations/20260619140510_add_analysis_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "analyses" (
+    "id" TEXT NOT NULL,
+    "law_id" TEXT NOT NULL,
+    "score" DOUBLE PRECISION NOT NULL,
+    "metrics" JSONB NOT NULL,
+    "warnings" JSONB NOT NULL,
+    "model_version" TEXT NOT NULL,
+    "cached" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "analyses_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "analyses" ADD CONSTRAINT "analyses_law_id_fkey" FOREIGN KEY ("law_id") REFERENCES "laws"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Law {
 
   uploadedByUserId String?      @map("uploaded_by_user_id")
   uploadedBy       User?        @relation(fields: [uploadedByUserId], references: [id], onDelete: SetNull)
+  analyses          Analysis[]
 
   isPublic        Boolean       @default(false) @map("is_public")
 
@@ -60,4 +61,18 @@ model Law {
   updatedAt       DateTime      @updatedAt @map("updated_at")
 
   @@map("laws")
+}
+
+model Analysis {
+  id           String   @id @default(uuid())
+  lawId        String   @map("law_id")
+  law          Law      @relation(fields: [lawId], references: [id], onDelete: Cascade)
+  score        Float
+  metrics      Json
+  warnings     Json
+  modelVersion String   @map("model_version")
+  cached       Boolean  @default(false)
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  @@map("analyses")
 }


### PR DESCRIPTION
## 📝 Descrição

Adiciona a tabela `Analysis` para persistir resultados de análise legislativa vinculados a `Law`, conforme decisão da issue #106 de manter análises em tabela própria em vez de campos analíticos em `Law`.

Principais mudanças:
- adiciona o model Prisma `Analysis` com `lawId`, `score`, `metrics`, `warnings`, `modelVersion`, `cached` e `createdAt`;
- adiciona a relação `Law.analyses`;
- cria a migration `add_analysis_table`;
- adiciona schemas Pydantic em `backend/app/models/analysis.py`.

Resolve a decisão NC-001/R-002 da spec de integração IA → Backend.

## 🏷️ Tipo de alteração
- [x] ✨ `feat:` Nova funcionalidade
- [ ] 🐛 `bugfix:` Correção de um erro
- [ ] ♻️ `refactor:` Refatoração de código (não altera as funcionalidades)
- [ ] 📚 `docs:` Atualização na documentação
- [ ] 🔧 `chore:` Tarefas de manutenção (dependências, configurações, etc.)

## ✅ Checklist de Revisão
- [x] O meu código segue os padrões do nosso Guia Definitivo.
- [x] Realizei uma auto-revisão detalhada do meu próprio código.
- [x] Os meus commits são atômicos e as mensagens seguem o padrão *Conventional Commits*.
- [x] O código não gera novos conflitos de merge (verifiquei a branch base).
- [x] A alteração não introduz novos avisos (warnings) ou erros no terminal.

## 🧪 Testes
- [x] Criei/atualizei testes para esta funcionalidade (se aplicável).
- [x] Testei a funcionalidade localmente e tudo está funcionando perfeitamente.

Validações executadas no ambiente Docker:
- `prisma validate`
- `prisma migrate status`
- `prisma db push`
- `pytest` (`26 passed`)

Observação: o `pytest` exibiu apenas um aviso de permissão ao tentar escrever cache em `/app/.pytest_cache`, sem falha de teste.

## 🖼️ Capturas de tela ou Vídeos (Se aplicável)

Não aplicável.
