### PR TITLE
feat: implementa interface e layout da pagina de perfil #135

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const nextJest = require("next/jest");
 
 const createJestConfig = nextJest({ dir: "./" });

--- a/frontend/src/app/profile/__tests__/page.test.tsx
+++ b/frontend/src/app/profile/__tests__/page.test.tsx
@@ -60,7 +60,7 @@ describe("ProfilePage (Client component)", () => {
     });
   });
 
-  it("TC-02: renderiza as informações iniciais do perfil do usuário logado", () => {
+  it("TC-02: renderiza as informações iniciais do perfil do usuário logado", async () => {
     (useAuth as jest.Mock).mockReturnValue({
       user: mockUser,
       token: "mock-jwt-token",
@@ -68,6 +68,10 @@ describe("ProfilePage (Client component)", () => {
     });
 
     render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalled();
+    });
 
     const nameInput = screen.getByLabelText("Nome") as HTMLInputElement;
     const emailInput = screen.getByLabelText("E-mail") as HTMLInputElement;
@@ -88,6 +92,10 @@ describe("ProfilePage (Client component)", () => {
     });
 
     render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalled();
+    });
 
     const nameInput = screen.getByLabelText("Nome");
     const saveButton = screen.getByRole("button", { name: /Salvar Alterações/i });
@@ -164,7 +172,7 @@ describe("ProfilePage (Client component)", () => {
     });
   });
 
-  it("TC-06: cancela as alterações e restaura o nome original", () => {
+  it("TC-06: cancela as alterações e restaura o nome original", async () => {
     (useAuth as jest.Mock).mockReturnValue({
       user: mockUser,
       token: "mock-jwt-token",
@@ -172,6 +180,10 @@ describe("ProfilePage (Client component)", () => {
     });
 
     render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalled();
+    });
 
     const nameInput = screen.getByLabelText("Nome") as HTMLInputElement;
     const cancelButton = screen.getByRole("button", { name: /Cancelar/i });

--- a/frontend/src/app/profile/__tests__/page.test.tsx
+++ b/frontend/src/app/profile/__tests__/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ProfilePage from "../page";
 import { useAuth } from "../../../contexts/AuthContext";
 import { useRouter } from "next/navigation";
-import { updateProfile } from "../../../lib/api/users";
+import { getProfile, updateProfile } from "../../../lib/api/users";
 import { toast } from "sonner";
 
 jest.mock("../../../contexts/AuthContext", () => ({
@@ -15,6 +15,7 @@ jest.mock("next/navigation", () => ({
 
 jest.mock("../../../lib/api/users", () => ({
   updateProfile: jest.fn(),
+  getProfile: jest.fn(),
 }));
 
 jest.mock("sonner", () => ({
@@ -42,6 +43,7 @@ describe("ProfilePage (Client component)", () => {
     (useRouter as jest.Mock).mockReturnValue({
       push: mockPush,
     });
+    (getProfile as jest.Mock).mockResolvedValue(mockUser);
   });
 
   it("TC-01: redireciona para /login se o usuário não estiver autenticado", async () => {
@@ -109,8 +111,16 @@ describe("ProfilePage (Client component)", () => {
 
     render(<ProfilePage />);
 
+    // Aguarda a carga inicial assíncrona do getProfile terminar
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalled();
+    });
+
     const nameInput = screen.getByLabelText("Nome");
     const saveButton = screen.getByRole("button", { name: /Salvar Alterações/i });
+
+    // Limpa chamadas de renderização/busca inicial
+    mockUpdateUserInSession.mockClear();
 
     fireEvent.change(nameInput, { target: { value: "Carlos Drummond de Andrade" } });
     fireEvent.click(saveButton);
@@ -133,8 +143,16 @@ describe("ProfilePage (Client component)", () => {
 
     render(<ProfilePage />);
 
+    // Aguarda a carga inicial assíncrona do getProfile terminar
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalled();
+    });
+
     const nameInput = screen.getByLabelText("Nome");
     const saveButton = screen.getByRole("button", { name: /Salvar Alterações/i });
+
+    // Limpa chamadas de renderização/busca inicial
+    mockUpdateUserInSession.mockClear();
 
     fireEvent.change(nameInput, { target: { value: "Carlos Drummond de Andrade" } });
     fireEvent.click(saveButton);
@@ -164,5 +182,48 @@ describe("ProfilePage (Client component)", () => {
     fireEvent.click(cancelButton);
 
     expect(nameInput.value).toBe("Carlos Drummond");
+  });
+
+  it("TC-07: sincroniza o nome do usuário quando ele é carregado assincronamente (null -> user carregado)", async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: null,
+      token: null,
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    const { rerender } = render(<ProfilePage />);
+
+    expect(screen.queryByLabelText("Nome")).not.toBeInTheDocument();
+
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockUser,
+      token: "mock-jwt-token",
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    (getProfile as jest.Mock).mockResolvedValue(mockUser);
+
+    rerender(<ProfilePage />);
+
+    await waitFor(() => {
+      const nameInput = screen.getByLabelText("Nome") as HTMLInputElement;
+      expect(nameInput.value).toBe("Carlos Drummond");
+    });
+  });
+
+  it("TC-08: dispara a requisição de busca de perfil na API ao carregar a página", async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockUser,
+      token: "mock-jwt-token",
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    (getProfile as jest.Mock).mockResolvedValue(mockUser);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalledWith("user-123", "mock-jwt-token");
+    });
   });
 });

--- a/frontend/src/app/profile/__tests__/page.test.tsx
+++ b/frontend/src/app/profile/__tests__/page.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ProfilePage from "../page";
+import { useAuth } from "../../../contexts/AuthContext";
+import { useRouter } from "next/navigation";
+import { updateProfile } from "../../../lib/api/users";
+import { toast } from "sonner";
+
+jest.mock("../../../contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("../../../lib/api/users", () => ({
+  updateProfile: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("ProfilePage (Client component)", () => {
+  const mockPush = jest.fn();
+  const mockUpdateUserInSession = jest.fn();
+
+  const mockUser = {
+    id: "user-123",
+    name: "Carlos Drummond",
+    email: "carlos@drummond.com",
+    role: "ADMIN",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRouter as jest.Mock).mockReturnValue({
+      push: mockPush,
+    });
+  });
+
+  it("TC-01: redireciona para /login se o usuário não estiver autenticado", async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: null,
+      token: null,
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    render(<ProfilePage />);
+
+    expect(mockPush).toHaveBeenCalledWith("/login");
+  });
+
+  it("TC-02: renderiza as informações iniciais do perfil do usuário logado", () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockUser,
+      token: "mock-jwt-token",
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    render(<ProfilePage />);
+
+    const nameInput = screen.getByLabelText("Nome") as HTMLInputElement;
+    const emailInput = screen.getByLabelText("E-mail") as HTMLInputElement;
+
+    expect(nameInput.value).toBe("Carlos Drummond");
+    expect(emailInput.value).toBe("carlos@drummond.com");
+    expect(emailInput).toBeDisabled();
+
+    expect(screen.getByText("ADMIN")).toBeInTheDocument();
+    expect(screen.getByText("Administrador")).toBeInTheDocument();
+  });
+
+  it("TC-03: exibe erro de validação client-side se o nome for menor que 3 caracteres", async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockUser,
+      token: "mock-jwt-token",
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    render(<ProfilePage />);
+
+    const nameInput = screen.getByLabelText("Nome");
+    const saveButton = screen.getByRole("button", { name: /Salvar Alterações/i });
+
+    fireEvent.change(nameInput, { target: { value: "Ca" } });
+    fireEvent.click(saveButton);
+
+    expect(screen.getByText("O nome deve conter pelo menos 3 caracteres.")).toBeInTheDocument();
+    expect(updateProfile).not.toHaveBeenCalled();
+  });
+
+  it("TC-04: chama a API de atualização, propaga no contexto e exibe toast de sucesso ao salvar", async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockUser,
+      token: "mock-jwt-token",
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    const updatedUser = { ...mockUser, name: "Carlos Drummond de Andrade" };
+    (updateProfile as jest.Mock).mockResolvedValue(updatedUser);
+
+    render(<ProfilePage />);
+
+    const nameInput = screen.getByLabelText("Nome");
+    const saveButton = screen.getByRole("button", { name: /Salvar Alterações/i });
+
+    fireEvent.change(nameInput, { target: { value: "Carlos Drummond de Andrade" } });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateProfile).toHaveBeenCalledWith("user-123", "Carlos Drummond de Andrade", "mock-jwt-token");
+      expect(mockUpdateUserInSession).toHaveBeenCalledWith(updatedUser);
+      expect(toast.success).toHaveBeenCalledWith("Perfil atualizado com sucesso!");
+    });
+  });
+
+  it("TC-05: exibe toast de erro se a requisição da API falhar", async () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockUser,
+      token: "mock-jwt-token",
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    (updateProfile as jest.Mock).mockRejectedValue(new Error("Erro de autorização (403)"));
+
+    render(<ProfilePage />);
+
+    const nameInput = screen.getByLabelText("Nome");
+    const saveButton = screen.getByRole("button", { name: /Salvar Alterações/i });
+
+    fireEvent.change(nameInput, { target: { value: "Carlos Drummond de Andrade" } });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateProfile).toHaveBeenCalled();
+      expect(mockUpdateUserInSession).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith("Erro de autorização (403)");
+    });
+  });
+
+  it("TC-06: cancela as alterações e restaura o nome original", () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      user: mockUser,
+      token: "mock-jwt-token",
+      updateUserInSession: mockUpdateUserInSession,
+    });
+
+    render(<ProfilePage />);
+
+    const nameInput = screen.getByLabelText("Nome") as HTMLInputElement;
+    const cancelButton = screen.getByRole("button", { name: /Cancelar/i });
+
+    fireEvent.change(nameInput, { target: { value: "Alteração Temporária" } });
+    expect(nameInput.value).toBe("Alteração Temporária");
+
+    fireEvent.click(cancelButton);
+
+    expect(nameInput.value).toBe("Carlos Drummond");
+  });
+});

--- a/frontend/src/app/profile/__tests__/page.test.tsx
+++ b/frontend/src/app/profile/__tests__/page.test.tsx
@@ -53,7 +53,9 @@ describe("ProfilePage (Client component)", () => {
 
     render(<ProfilePage />);
 
-    expect(mockPush).toHaveBeenCalledWith("/login");
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/login");
+    });
   });
 
   it("TC-02: renderiza as informações iniciais do perfil do usuário logado", () => {

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../../contexts/AuthContext";
+import { updateProfile } from "../../lib/api/users";
+import { toast } from "sonner";
+import { Loader2, User, Mail, Shield, Save, X } from "lucide-react";
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const { user, token, updateUserInSession } = useAuth();
+
+  const [name, setName] = useState(user?.name || "");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (!user) {
+        router.push("/login");
+      }
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [user, router]);
+
+  if (!user) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-slate-500" />
+      </div>
+    );
+  }
+
+  const handleCancel = () => {
+    setName(user.name);
+    setError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (name.trim().length < 3) {
+      setError("O nome deve conter pelo menos 3 caracteres.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const updatedUser = await updateProfile(user.id, name.trim(), token || "");
+      updateUserInSession(updatedUser);
+      toast.success("Perfil atualizado com sucesso!");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Erro desconhecido";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-12 sm:px-6">
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="bg-gradient-to-r from-[#1e3a5f] to-[#2d5a8c] px-6 py-8 text-white">
+          <h1 className="text-2xl font-bold">Meu Perfil</h1>
+          <p className="mt-1 text-sm text-blue-100">
+            Gerencie as informações básicas da sua conta.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} key={user.id} className="p-6 space-y-6">
+          <div className="space-y-2">
+            <label htmlFor="name" className="text-sm font-semibold text-slate-700 flex items-center gap-2">
+              <User className="h-4 w-4 text-slate-400" />
+              Nome
+            </label>
+            <input
+              id="name"
+              type="text"
+              value={name || user.name}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (error) setError(null);
+              }}
+              className={`w-full rounded-lg border px-4 py-2.5 text-sm outline-none transition-all ${
+                error
+                  ? "border-red-300 focus:border-red-500 focus:ring-1 focus:ring-red-500"
+                  : "border-slate-200 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              }`}
+            />
+            {error && (
+              <p className="text-xs font-medium text-red-500">{error}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-semibold text-slate-700 flex items-center gap-2">
+              <Mail className="h-4 w-4 text-slate-400" />
+              E-mail
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={user.email}
+              disabled
+              className="w-full rounded-lg border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm text-slate-500 outline-none cursor-not-allowed"
+            />
+          </div>
+
+          <div className="rounded-lg bg-slate-50 p-4 border border-slate-100 flex items-start gap-3">
+            <Shield className="h-5 w-5 text-slate-400 mt-0.5" />
+            <div>
+              <h3 className="text-sm font-semibold text-slate-700">Tipo de Conta</h3>
+              <p className="text-xs text-slate-500 mt-0.5">
+                Nível de acesso do usuário no sistema CrivoAI.
+              </p>
+              <div className="mt-2 flex items-center gap-2">
+                <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-bold text-blue-700 border border-blue-200 uppercase">
+                  {user.role}
+                </span>
+                <span className="text-xs text-slate-400 font-medium">
+                  {user.role === "ADMIN" ? "Administrador" : "Usuário Comum"}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-3 pt-4 border-t border-slate-100">
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={isSubmitting}
+              className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50"
+            >
+              <X className="h-4 w-4" />
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="inline-flex items-center gap-2 rounded-lg bg-[#1e3a5f] px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#162a45] disabled:opacity-50"
+            >
+              {isSubmitting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="h-4 w-4" />
+              )}
+              Salvar Alterações
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -6,6 +6,8 @@ import { useAuth } from "../../contexts/AuthContext";
 import { updateProfile } from "../../lib/api/users";
 import { toast } from "sonner";
 import { Loader2, User, Mail, Shield, Save, X } from "lucide-react";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
 
 export default function ProfilePage() {
   const router = useRouter();
@@ -77,22 +79,19 @@ export default function ProfilePage() {
               <User className="h-4 w-4 text-slate-400" />
               Nome
             </label>
-            <input
+            <Input
               id="name"
               type="text"
-              value={name || user.name}
+              value={name}
               onChange={(e) => {
                 setName(e.target.value);
                 if (error) setError(null);
               }}
-              className={`w-full rounded-lg border px-4 py-2.5 text-sm outline-none transition-all ${
-                error
-                  ? "border-red-300 focus:border-red-500 focus:ring-1 focus:ring-red-500"
-                  : "border-slate-200 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
-              }`}
+              aria-invalid={!!error}
+              aria-describedby={error ? "name-error" : undefined}
             />
             {error && (
-              <p className="text-xs font-medium text-red-500">{error}</p>
+              <p id="name-error" className="text-xs font-medium text-red-500">{error}</p>
             )}
           </div>
 
@@ -101,12 +100,11 @@ export default function ProfilePage() {
               <Mail className="h-4 w-4 text-slate-400" />
               E-mail
             </label>
-            <input
+            <Input
               id="email"
               type="email"
               value={user.email}
               disabled
-              className="w-full rounded-lg border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm text-slate-500 outline-none cursor-not-allowed"
             />
           </div>
 
@@ -129,19 +127,18 @@ export default function ProfilePage() {
           </div>
 
           <div className="flex items-center justify-end gap-3 pt-4 border-t border-slate-100">
-            <button
+            <Button
               type="button"
+              variant="outline"
               onClick={handleCancel}
               disabled={isSubmitting}
-              className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50"
             >
               <X className="h-4 w-4" />
               Cancelar
-            </button>
-            <button
+            </Button>
+            <Button
               type="submit"
               disabled={isSubmitting}
-              className="inline-flex items-center gap-2 rounded-lg bg-[#1e3a5f] px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors hover:bg-[#162a45] disabled:opacity-50"
             >
               {isSubmitting ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -149,7 +146,7 @@ export default function ProfilePage() {
                 <Save className="h-4 w-4" />
               )}
               Salvar Alterações
-            </button>
+            </Button>
           </div>
         </form>
       </div>

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../../contexts/AuthContext";
-import { updateProfile } from "../../lib/api/users";
+import { getProfile, updateProfile } from "../../lib/api/users";
 import { toast } from "sonner";
 import { Loader2, User, Mail, Shield, Save, X } from "lucide-react";
 import { Button } from "../../components/ui/button";
@@ -26,6 +26,38 @@ export default function ProfilePage() {
 
     return () => clearTimeout(timer);
   }, [user, router]);
+
+  // Efeito para sincronização inicial do nome quando o usuário é carregado do localStorage
+  useEffect(() => {
+    if (user?.name) {
+      setName(user.name);
+    }
+  }, [user?.id, user?.name]);
+
+  // Efeito para buscar dados do perfil em tempo real na API ao carregar a página
+  useEffect(() => {
+    if (!user || !token) return;
+
+    let active = true;
+
+    async function fetchUserData() {
+      try {
+        const freshUser = await getProfile(user.id, token);
+        if (active) {
+          updateUserInSession(freshUser);
+          setName(freshUser.name);
+        }
+      } catch (err) {
+        console.error("Erro ao buscar dados do perfil na API:", err);
+      }
+    }
+
+    void fetchUserData();
+
+    return () => {
+      active = false;
+    };
+  }, [user?.id, token]);
 
   if (!user) {
     return (

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -2,42 +2,26 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "../../contexts/AuthContext";
+import { useAuth, type AuthUser } from "../../contexts/AuthContext";
 import { getProfile, updateProfile } from "../../lib/api/users";
 import { toast } from "sonner";
 import { Loader2, User, Mail, Shield, Save, X } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 
-export default function ProfilePage() {
-  const router = useRouter();
-  const { user, token, updateUserInSession } = useAuth();
+interface ProfileFormProps {
+  user: AuthUser;
+  token: string;
+  updateUserInSession: (updatedUser: AuthUser) => void;
+}
 
-  const [name, setName] = useState(user?.name || "");
+function ProfileForm({ user, token, updateUserInSession }: ProfileFormProps) {
+  const [name, setName] = useState(user.name || "");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (!user) {
-        router.push("/login");
-      }
-    }, 100);
-
-    return () => clearTimeout(timer);
-  }, [user, router]);
-
-  // Efeito para sincronização inicial do nome quando o usuário é carregado do localStorage
-  useEffect(() => {
-    if (user?.name) {
-      setName(user.name);
-    }
-  }, [user?.id, user?.name]);
-
   // Efeito para buscar dados do perfil em tempo real na API ao carregar a página
   useEffect(() => {
-    if (!user || !token) return;
-
     let active = true;
 
     async function fetchUserData() {
@@ -57,15 +41,8 @@ export default function ProfilePage() {
     return () => {
       active = false;
     };
-  }, [user?.id, token]);
-
-  if (!user) {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-slate-500" />
-      </div>
-    );
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user.id, token]);
 
   const handleCancel = () => {
     setName(user.name);
@@ -84,7 +61,7 @@ export default function ProfilePage() {
     setIsSubmitting(true);
 
     try {
-      const updatedUser = await updateProfile(user.id, name.trim(), token || "");
+      const updatedUser = await updateProfile(user.id, name.trim(), token);
       updateUserInSession(updatedUser);
       toast.success("Perfil atualizado com sucesso!");
     } catch (err) {
@@ -96,6 +73,108 @@ export default function ProfilePage() {
   };
 
   return (
+    <form onSubmit={handleSubmit} className="p-6 space-y-6">
+      <div className="space-y-2">
+        <label htmlFor="name" className="text-sm font-semibold text-slate-700 flex items-center gap-2">
+          <User className="h-4 w-4 text-slate-400" />
+          Nome
+        </label>
+        <Input
+          id="name"
+          type="text"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            if (error) setError(null);
+          }}
+          aria-invalid={!!error}
+          aria-describedby={error ? "name-error" : undefined}
+        />
+        {error && (
+          <p id="name-error" className="text-xs font-medium text-red-500">{error}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="email" className="text-sm font-semibold text-slate-700 flex items-center gap-2">
+          <Mail className="h-4 w-4 text-slate-400" />
+          E-mail
+        </label>
+        <Input
+          id="email"
+          type="email"
+          value={user.email}
+          disabled
+        />
+      </div>
+
+      <div className="rounded-lg bg-slate-50 p-4 border border-slate-100 flex items-start gap-3">
+        <Shield className="h-5 w-5 text-slate-400 mt-0.5" />
+        <div>
+          <h3 className="text-sm font-semibold text-slate-700">Tipo de Conta</h3>
+          <p className="text-xs text-slate-500 mt-0.5">
+            Nível de acesso do usuário no sistema CrivoAI.
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-bold text-blue-700 border border-blue-200 uppercase">
+              {user.role}
+            </span>
+            <span className="text-xs text-slate-400 font-medium">
+              {user.role === "ADMIN" ? "Administrador" : "Usuário Comum"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-3 pt-4 border-t border-slate-100">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleCancel}
+          disabled={isSubmitting}
+        >
+          <X className="h-4 w-4" />
+          Cancelar
+        </Button>
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="h-4 w-4" />
+          )}
+          Salvar Alterações
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const { user, token, updateUserInSession } = useAuth();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (!user) {
+        router.push("/login");
+      }
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [user, router]);
+
+  if (!user || !token) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-slate-500" />
+      </div>
+    );
+  }
+
+  return (
     <div className="mx-auto max-w-2xl px-4 py-12 sm:px-6">
       <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
         <div className="bg-gradient-to-r from-[#1e3a5f] to-[#2d5a8c] px-6 py-8 text-white">
@@ -105,82 +184,17 @@ export default function ProfilePage() {
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} key={user.id} className="p-6 space-y-6">
-          <div className="space-y-2">
-            <label htmlFor="name" className="text-sm font-semibold text-slate-700 flex items-center gap-2">
-              <User className="h-4 w-4 text-slate-400" />
-              Nome
-            </label>
-            <Input
-              id="name"
-              type="text"
-              value={name}
-              onChange={(e) => {
-                setName(e.target.value);
-                if (error) setError(null);
-              }}
-              aria-invalid={!!error}
-              aria-describedby={error ? "name-error" : undefined}
-            />
-            {error && (
-              <p id="name-error" className="text-xs font-medium text-red-500">{error}</p>
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <label htmlFor="email" className="text-sm font-semibold text-slate-700 flex items-center gap-2">
-              <Mail className="h-4 w-4 text-slate-400" />
-              E-mail
-            </label>
-            <Input
-              id="email"
-              type="email"
-              value={user.email}
-              disabled
-            />
-          </div>
-
-          <div className="rounded-lg bg-slate-50 p-4 border border-slate-100 flex items-start gap-3">
-            <Shield className="h-5 w-5 text-slate-400 mt-0.5" />
-            <div>
-              <h3 className="text-sm font-semibold text-slate-700">Tipo de Conta</h3>
-              <p className="text-xs text-slate-500 mt-0.5">
-                Nível de acesso do usuário no sistema CrivoAI.
-              </p>
-              <div className="mt-2 flex items-center gap-2">
-                <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-bold text-blue-700 border border-blue-200 uppercase">
-                  {user.role}
-                </span>
-                <span className="text-xs text-slate-400 font-medium">
-                  {user.role === "ADMIN" ? "Administrador" : "Usuário Comum"}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <div className="flex items-center justify-end gap-3 pt-4 border-t border-slate-100">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleCancel}
-              disabled={isSubmitting}
-            >
-              <X className="h-4 w-4" />
-              Cancelar
-            </Button>
-            <Button
-              type="submit"
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Save className="h-4 w-4" />
-              )}
-              Salvar Alterações
-            </Button>
-          </div>
-        </form>
+        {/* 
+          O uso da chave key={user.id} no subcomponente reconstrói completamente
+          o formulário com o estado inicial correto assim que o usuário é carregado,
+          eliminando a necessidade de useEffects sincronizadores síncronos (evita cascading renders).
+        */}
+        <ProfileForm 
+          user={user} 
+          token={token} 
+          updateUserInSession={updateUserInSession} 
+          key={user.id} 
+        />
       </div>
     </div>
   );

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -33,6 +33,7 @@ function ProfileForm({ user, token, updateUserInSession }: ProfileFormProps) {
         }
       } catch (err) {
         console.error("Erro ao buscar dados do perfil na API:", err);
+        toast.error("Não foi possível sincronizar seus dados em tempo real.");
       }
     }
 

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -11,6 +11,7 @@ import {
   UserPlus,
 } from "lucide-react";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
+import { Toaster } from "./ui/sonner";
 
 const navItems = [
   { href: "/", label: "Dashboard" },
@@ -130,6 +131,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <main className="flex-1">{children}</main>
         <Footer />
       </div>
+      <Toaster />
     </AuthProvider>
   );
 }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -14,6 +14,8 @@ import {
   type AuthUser,
 } from "@/lib/api/auth";
 
+export type { AuthUser };
+
 type AuthContextType = {
   user: AuthUser | null;
   token: string | null;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -20,6 +20,7 @@ type AuthContextType = {
   login: (email: string, password: string) => Promise<void>;
   register: (name: string, email: string, password: string) => Promise<void>;
   logout: () => void;
+  updateUserInSession: (updatedUser: AuthUser) => void;
 };
 
 const SESSION_KEY = "crivoai_session";
@@ -63,6 +64,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSession(null);
   };
 
+  function updateUserInSession(updatedUser: AuthUser) {
+    if (!session) {
+      return;
+    }
+    saveSession({ ...session, user: updatedUser });
+  }
+
   return (
     <AuthContext.Provider
       value={{
@@ -71,6 +79,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         login,
         register,
         logout,
+        updateUserInSession,
       }}
     >
       {children}

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -8,3 +8,10 @@ export function updateProfile(id: string, name: string, token: string) {
     body: JSON.stringify({ name }),
   });
 }
+
+export function getProfile(id: string, token: string) {
+  return apiRequest<AuthUser>(`/users/${id}`, {
+    method: "GET",
+    token,
+  });
+}

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -1,0 +1,10 @@
+import { apiRequest } from "@/lib/api/client";
+import { type AuthUser } from "./auth";
+
+export function updateProfile(id: string, name: string, token: string) {
+  return apiRequest<AuthUser>(`/users/${id}`, {
+    method: "PATCH",
+    token,
+    body: JSON.stringify({ name }),
+  });
+}

--- a/specs/005-user-profile/plan.md
+++ b/specs/005-user-profile/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Tela de Perfil do Usuário — R2
+
+**Feature**: Tela de Perfil do Usuário
+**ID da Spec**: `specs/005-user-profile`
+
+## Abordagem Técnica
+
+O desenvolvimento consistirá em criar a tela de perfil na pasta do frontend, implementar a chamada da API, expor o método de atualização da sessão no contexto de autenticação global e integrar com Toasts de feedback para o usuário.
+
+---
+
+## 1. Modificações de Arquivos e Novas Implementações
+
+### A. Integração com API (Frontend)
+
+Criar o arquivo `frontend/src/lib/api/users.ts` com funções que mapeiam as rotas de usuários expostas pelo backend, passando o token JWT para autenticação.
+
+```typescript
+import { apiRequest } from "@/lib/api/client";
+import { type AuthUser } from "./auth";
+
+/**
+ * Atualiza o nome do usuário logado.
+ */
+export function updateProfile(id: string, name: string, token: string) {
+  return apiRequest<AuthUser>(`/users/${id}`, {
+    method: "PATCH",
+    token,
+    body: JSON.stringify({ name }),
+  });
+}
+```
+
+### B. Atualização do Contexto Global de Autenticação
+
+Modificar o arquivo [AuthContext.tsx](file:///C:/Users/vinic/Desktop/MDS/2026-1-Squad07/frontend/src/contexts/AuthContext.tsx) para expor a função `updateUserInSession(updatedUser: AuthUser)`, permitindo que alterações de perfil se propaguem para a interface em tempo real e atualizem o `localStorage` do navegador:
+
+```typescript
+type AuthContextType = {
+  // ... campos existentes ...
+  updateUserInSession: (updatedUser: AuthUser) => void;
+};
+
+// ...
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  // ...
+  function updateUserInSession(updatedUser: AuthUser) {
+    if (!session) return;
+    const nextSession = { ...session, user: updatedUser };
+    saveSession(nextSession);
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        // ...
+        updateUserInSession,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+```
+
+### C. Implementação da Tela `/profile`
+
+Criar a página `frontend/src/app/profile/page.tsx`. Ela deve ser um `Client Component` contendo:
+
+- Proteção de Rota: Uso de `useEffect` com redirecionamento via `useRouter` caso `user` seja nulo.
+- Estado de Carregamento (Loading): Exibição de um spinner ou skeleton enquanto o estado de `user` no contexto não é inicializado.
+- Interface de Usuário:
+  - Input para Nome (editável).
+  - Input para E-mail (desabilitado).
+  - Badges ou elementos estáticos para exibir o Tipo de Conta (COMMON / ADMIN) e a Data de Criação do perfil formatada.
+- Ações:
+  - Envio do formulário via evento `onSubmit` com tratamento de erro e loading.
+  - Cancelamento: Limpeza de estados não salvos e reinicialização com o nome original do contexto.
+- Notificações:
+  - Toasts de sucesso ("Perfil atualizado com sucesso!") e erro ("Ocorreu um erro ao atualizar o perfil. Tente novamente.").
+
+---
+
+## 2. Padrão de Estilos e Layout
+
+O design da tela de perfil deve respeitar a linguagem visual já estabelecida no CrivoAI (Premium Dark Mode, gradientes suaves, bordas sutis e tipografia Outfit/Inter).
+
+- Card centralizado.
+- Sombras suaves e efeitos hover.
+- Botões utilizando a paleta de cores primária e secundária padrão do sistema.
+- Responsividade garantida para resoluções mobile (Flexbox/Grid do CSS).
+
+---
+
+## 3. Resolvendo NEEDS CLARIFICATION
+
+Para possibilitar os testes imediatos sem dependência de alteração da branch principal do backend:
+
+1. Durante o desenvolvimento local, se o usuário logado for `COMMON`, o salvamento retornará erro `403 Forbidden` do backend.
+2. A solução técnica recomendada no frontend é garantir o tratamento elegante de erros (`403 Forbidden`) explicando claramente o motivo, enquanto o PR do backend com o ajuste de permissões (retirando `require_admin_user` global) é processado.
+3. Para validar o caminho feliz (happy path) localmente no desenvolvimento atual, será recomendado realizar os testes com um usuário que possua role `ADMIN` (semeado via banco ou criado manualmente).

--- a/specs/005-user-profile/plan.md
+++ b/specs/005-user-profile/plan.md
@@ -13,7 +13,7 @@ O desenvolvimento consistirá em criar a tela de perfil na pasta do frontend, im
 
 ### A. Integração com API (Frontend)
 
-Criar o arquivo `frontend/src/lib/api/users.ts` com funções que mapeiam as rotas de usuários expostas pelo backend, passando o token JWT para autenticação.
+Criar/atualizar o arquivo `frontend/src/lib/api/users.ts` com funções que mapeiam as rotas de usuários expostas pelo backend, passando o token JWT para autenticação.
 
 ```typescript
 import { apiRequest } from "@/lib/api/client";
@@ -27,6 +27,16 @@ export function updateProfile(id: string, name: string, token: string) {
     method: "PATCH",
     token,
     body: JSON.stringify({ name }),
+  });
+}
+
+/**
+ * Obtém os dados de perfil do usuário logado em tempo real.
+ */
+export function getProfile(id: string, token: string) {
+  return apiRequest<AuthUser>(`/users/${id}`, {
+    method: "GET",
+    token,
   });
 }
 ```
@@ -69,6 +79,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 Criar a página `frontend/src/app/profile/page.tsx`. Ela deve ser um `Client Component` contendo:
 
 - Proteção de Rota: Uso de `useEffect` com redirecionamento via `useRouter` caso `user` seja nulo.
+- Sincronização de Hidratação: Uso de `useEffect` para preencher o input de nome quando a sessão do usuário é carregada assincronamente.
+- Sincronização com o Backend: Uso de `useEffect` para chamar `getProfile` ao montar a página, atualizando a sessão global com os dados atualizados do banco.
 - Estado de Carregamento (Loading): Exibição de um spinner ou skeleton enquanto o estado de `user` no contexto não é inicializado.
 - Interface de Usuário:
   - Input para Nome (editável).

--- a/specs/005-user-profile/quickstart.md
+++ b/specs/005-user-profile/quickstart.md
@@ -1,0 +1,72 @@
+# Quickstart: Tela de Perfil do Usuário — R2
+
+Este guia orienta o desenvolvedor sobre como configurar o ambiente, rodar a aplicação e validar o funcionamento da tela de perfil de usuário localmente.
+
+---
+
+## 1. Preparação do Ambiente
+
+### Requisitos
+
+- Node.js 18+ instalado.
+- Python 3.11+ com `pip` instalado.
+- Banco de dados PostgreSQL configurado.
+
+### Passos para Inicialização
+
+1. **Backend**:
+   Certifique-se de que o backend está rodando na porta `8000`:
+
+   ```powershell
+   cd backend
+   # Ative o ambiente virtual
+   .venv\Scripts\Activate.ps1
+   # Instale as dependências
+   pip install -r requirements.txt
+   # Execute as migrations do Prisma se necessário
+   npx prisma db push
+   # Rode o servidor
+   uvicorn app.main:app --reload --port 8000
+   ```
+
+2. **Frontend**:
+   Em outro terminal, inicie o frontend na porta `3000`:
+
+   ```powershell
+   cd frontend
+   npm install
+   npm run dev
+   ```
+
+---
+
+## 2. Execução dos Testes Automatizados (TDD)
+
+Para rodar os testes do frontend criados para esta funcionalidade (Jest):
+
+```powershell
+cd frontend
+# Executar todos os testes com Jest
+npm run test
+
+# Executar testes em modo watch durante o desenvolvimento
+npx jest src/app/profile/__tests__/page.test.tsx --watch
+```
+
+---
+
+## 3. Fluxo de Validação Manual da Feature
+
+1. Acesse `http://localhost:3000/login` e realize a autenticação com um usuário com role de `ADMIN` (devido à limitação temporária da rota de API de usuários no backend).
+2. Acesse a URL `http://localhost:3000/profile` (ou clique no menu de perfil na Navbar).
+3. Verifique se os dados de e-mail (somente leitura) e nome são renderizados perfeitamente.
+4. Mude o valor do input "Nome", insira caracteres inválidos (< 3 caracteres) e verifique se a validação do cliente bloqueia o salvamento.
+5. Insira um nome válido, clique em "Salvar Alterações" e valide o surgimento do Toast de sucesso.
+6. Valide a alteração diretamente no banco de dados via Prisma Studio se desejar:
+
+   ```powershell
+   cd backend
+   npx prisma studio
+   ```
+
+   Consulte a tabela `User` para garantir que o campo `name` do respectivo `id` foi atualizado com sucesso.

--- a/specs/005-user-profile/quickstart.md
+++ b/specs/005-user-profile/quickstart.md
@@ -1,72 +1,67 @@
 # Quickstart: Tela de Perfil do Usuário — R2
 
-Este guia orienta o desenvolvedor sobre como configurar o ambiente, rodar a aplicação e validar o funcionamento da tela de perfil de usuário localmente.
+Este guia orienta o desenvolvedor sobre como configurar o ambiente, rodar a aplicação com Docker e validar o funcionamento da tela de perfil de usuário localmente.
 
 ---
 
-## 1. Preparação do Ambiente
+## 1. Preparação do Ambiente com Docker
 
 ### Requisitos
-
-- Node.js 18+ instalado.
-- Python 3.11+ com `pip` instalado.
-- Banco de dados PostgreSQL configurado.
+- Docker e Docker Compose instalados.
+- Node.js 18+ instalado no host local (para o frontend).
 
 ### Passos para Inicialização
 
-1. **Backend**:
-   Certifique-se de que o backend está rodando na porta `8000`:
-
+1. **Backend e Banco de Dados (Docker)**:
+   Suba o container do banco de dados PostgreSQL e da API FastAPI usando Docker Compose:
    ```powershell
-   cd backend
-   # Ative o ambiente virtual
-   .venv\Scripts\Activate.ps1
-   # Instale as dependências
-   pip install -r requirements.txt
-   # Execute as migrations do Prisma se necessário
-   npx prisma db push
-   # Rode o servidor
-   uvicorn app.main:app --reload --port 8000
+   # Sobe os containers em segundo plano com build atualizado
+   docker compose up -d --build
    ```
+   A API FastAPI estará disponível na porta `8000`.
 
-2. **Frontend**:
-   Em outro terminal, inicie o frontend na porta `3000`:
-
+2. **Frontend (Host Local)**:
+   Inicie o frontend na sua máquina local apontando para o backend da API:
    ```powershell
    cd frontend
    npm install
    npm run dev
    ```
+   Acesse a aplicação em `http://localhost:3000`.
 
 ---
 
 ## 2. Execução dos Testes Automatizados (TDD)
 
-Para rodar os testes do frontend criados para esta funcionalidade (Jest):
-
+### Testes do Frontend (Host Local)
+Como a interface roda no host, execute a suíte de testes de Jest localmente:
 ```powershell
 cd frontend
-# Executar todos os testes com Jest
+# Executar todos os testes
 npm run test
 
-# Executar testes em modo watch durante o desenvolvimento
-npx jest src/app/profile/__tests__/page.test.tsx --watch
+# Executar apenas os testes da página de perfil
+npx jest src/app/profile/__tests__/page.test.tsx
+```
+
+### Testes do Backend (Dentro do Docker)
+Caso necessite rodar a suite de testes de backend ou validação de cobertura:
+```powershell
+# Executa pytest de forma isolada dentro do container FastAPI
+docker compose exec app pytest
 ```
 
 ---
 
 ## 3. Fluxo de Validação Manual da Feature
 
-1. Acesse `http://localhost:3000/login` e realize a autenticação com um usuário com role de `ADMIN` (devido à limitação temporária da rota de API de usuários no backend).
+1. Acesse `http://localhost:3000/login` e realize a autenticação com um usuário com role de `ADMIN`.
 2. Acesse a URL `http://localhost:3000/profile` (ou clique no menu de perfil na Navbar).
 3. Verifique se os dados de e-mail (somente leitura) e nome são renderizados perfeitamente.
 4. Mude o valor do input "Nome", insira caracteres inválidos (< 3 caracteres) e verifique se a validação do cliente bloqueia o salvamento.
 5. Insira um nome válido, clique em "Salvar Alterações" e valide o surgimento do Toast de sucesso.
-6. Valide a alteração diretamente no banco de dados via Prisma Studio se desejar:
-
+6. Valide a alteração diretamente no banco de dados rodando o Prisma Studio dentro do container do app:
    ```powershell
-   cd backend
-   npx prisma studio
+   docker compose exec app npx prisma studio
    ```
-
-   Consulte a tabela `User` para garantir que o campo `name` do respectivo `id` foi atualizado com sucesso.
+   Abra `http://localhost:5555` no navegador para verificar as atualizações na tabela `User`.

--- a/specs/005-user-profile/spec.md
+++ b/specs/005-user-profile/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Tela de Perfil do Usuário — R2
+
+**Branch**: `feat/issue-135-perfil-usuario`
+**Criado em**: 2026-06-26
+**Status**: Draft
+**Issue**: #135
+**Depende de**: Ajuste na autenticação/autorização no backend (marcado em `NEEDS CLARIFICATION`).
+
+## Objetivo
+
+Implementar a interface de visualização e edição de perfil de usuário logado no frontend (Next.js), permitindo que o usuário consulte seus dados básicos (Nome, E-mail, Tipo de Conta) e edite seu nome com feedbacks visuais claros (toasts de sucesso e erro) e validações adequadas.
+
+---
+
+## Contexto
+
+Atualmente, o backend possui rotas CRUD de usuários em [backend/app/api/users.py](file:///C:/Users/vinic/Desktop/MDS/2026-1-Squad07/backend/app/api/users.py) e autenticação em [backend/app/api/auth.py](file:///C:/Users/vinic/Desktop/MDS/2026-1-Squad07/backend/app/api/auth.py). O frontend do CrivoAI necessita de uma área autenticada (`/profile`) onde o usuário logado consiga gerenciar suas informações básicas de cadastro.
+
+---
+
+## NEEDS CLARIFICATION (Pontos de Esclarecimento)
+
+> [!IMPORTANT]
+> **Conflito de Autorização no Roteador de Usuários**
+>
+> No backend, o roteador `/users` em [backend/app/api/users.py](file:///C:/Users/vinic/Desktop/MDS/2026-1-Squad07/backend/app/api/users.py) está configurado com a dependência global `require_admin_user`:
+> ```python
+> router = APIRouter(
+>     prefix="/users",
+>     tags=["users"],
+>     dependencies=[Depends(require_admin_user)],
+> )
+> ```
+> Isso impede que usuários com a role `COMMON` (usuários comuns) façam requisições de leitura ou escrita nos endpoints `/users/{user_id}`, resultando em `403 Forbidden`. 
+>
+> **Soluções Propostas para Alinhamento com o PO/Time**:
+> * **Opção A (Recomendada)**: Remover a dependência global `require_admin_user` do roteador `/users` e aplicá-la especificamente a rotas administrativas (como `GET /users` e `DELETE /users/{user_id}`). Para `GET /users/{user_id}` e `PATCH /users/{user_id}`, permitir acesso se o usuário autenticado for o proprietário do ID (`current_user.id == user_id`) ou se for `ADMIN`.
+> * **Opção B**: Criar um endpoint dedicado e autenticado `/users/me` no backend (usando apenas `Depends(get_current_user)`) para retornar e editar o perfil do próprio usuário logado.
+> * **Opção C**: Limitar a funcionalidade de edição de perfil apenas a usuários administradores nesta Sprint.
+
+---
+
+## Escopo
+
+### Incluído
+
+- **Página de Perfil (`/profile`)**:
+  - Layout responsivo, utilizando os padrões de design do sistema.
+  - Carregamento de dados básicos do usuário logado (Nome, E-mail, Tipo de Conta).
+  - Formulário para alteração de Nome.
+  - Validação no lado do cliente (Nome obrigatório, tamanho mínimo de 3 caracteres).
+  - Redirecionamento automático para a tela de login (`/login`) caso o usuário tente acessar a rota sem estar autenticado.
+- **Feedbacks Visuais**:
+  - Estado de carregamento (*skeleton screen* ou *loading spinner*).
+  - Notificações instantâneas (toasts) indicando sucesso ou erro ao salvar dados.
+- **Integração**:
+  - Chamada HTTP para salvar modificações via `PATCH /api/users/{id}` (ou a solução de `/users/me` definida na seção *Clarification*).
+  - Atualização do contexto global de autenticação no frontend após salvamento bem-sucedido.
+
+### Fora de Escopo
+
+- Redefinição de senha a partir da tela de perfil (deve ser tratada em issue de segurança/recuperação futura).
+- Alteração de endereço de e-mail (e-mail é usado como chave única e será somente leitura).
+- Upload de avatar ou foto de perfil (não suportado pelo modelo de dados atual).
+
+---
+
+## Interface e Protótipo de Fluxo
+
+1. **Acesso**: O usuário acessa a rota `/profile` ou clica em seu nome na barra de navegação.
+2. **Autenticação**: O frontend verifica a presença do token. Se ausente, redireciona para `/login` salvando a URL de retorno.
+3. **Leitura**: A página exibe estado de loading enquanto chama a API.
+4. **Formulário**:
+   - Campo **Nome**: Input de texto, editável.
+   - Campo **E-mail**: Input desabilitado (somente leitura).
+   - Campo **Tipo de Conta (Role)**: Exibição visual do tipo de conta (COMMON/ADMIN).
+5. **Ações**:
+   - Botão **Salvar Alterações**: Envia o payload `{ "name": "Novo Nome" }`. Desabilitado durante o envio.
+   - Botão **Cancelar**: Descarta alterações não salvas e volta ao estado anterior.
+
+---
+
+## Contratos de API Propostos
+
+### Buscar Dados do Perfil
+* **Endpoint**: `GET /api/users/{user_id}`
+* **Headers**: `Authorization: Bearer <token>`
+* **Resposta de Sucesso (200 OK)**:
+  ```json
+  {
+    "id": "user-uuid-123",
+    "name": "Nome do Usuário",
+    "email": "usuario@exemplo.com",
+    "role": "COMMON"
+  }
+  ```
+
+### Atualizar Nome do Perfil
+* **Endpoint**: `PATCH /api/users/{user_id}`
+* **Headers**: `Authorization: Bearer <token>`
+* **Payload**:
+  ```json
+  {
+    "name": "Novo Nome do Usuário"
+  }
+  ```
+* **Resposta de Sucesso (200 OK)**:
+  ```json
+  {
+    "id": "user-uuid-123",
+    "name": "Novo Nome do Usuário",
+    "email": "usuario@exemplo.com",
+    "role": "COMMON"
+  }
+  ```
+* **Resposta de Erro (400 Bad Request / 409 Conflict)**:
+  ```json
+  {
+    "detail": "Nome inválido ou erro de validação."
+  }
+  ```

--- a/specs/005-user-profile/spec.md
+++ b/specs/005-user-profile/spec.md
@@ -1,10 +1,10 @@
 # Feature Specification: Tela de Perfil do Usuário — R2
 
 **Branch**: `feat/issue-135-perfil-usuario`
-**Criado em**: 2026-06-26
-**Status**: Draft
+**Criado em**: 2026-06-26 (Atualizado em 2026-06-30)
+**Status**: Approved
 **Issue**: #135
-**Depende de**: Ajuste na autenticação/autorização no backend (marcado em `NEEDS CLARIFICATION`).
+**Depende de**: Ajuste na autenticação/autorização no backend (resolvido na Issue #147 e PR #154).
 
 ## Objetivo
 
@@ -21,22 +21,9 @@ Atualmente, o backend possui rotas CRUD de usuários em [backend/app/api/users.p
 ## NEEDS CLARIFICATION (Pontos de Esclarecimento)
 
 > [!IMPORTANT]
-> **Conflito de Autorização no Roteador de Usuários**
+> **Conflito de Autorização no Roteador de Usuários (RESOLVIDO)**
 >
-> No backend, o roteador `/users` em [backend/app/api/users.py](file:///C:/Users/vinic/Desktop/MDS/2026-1-Squad07/backend/app/api/users.py) está configurado com a dependência global `require_admin_user`:
-> ```python
-> router = APIRouter(
->     prefix="/users",
->     tags=["users"],
->     dependencies=[Depends(require_admin_user)],
-> )
-> ```
-> Isso impede que usuários com a role `COMMON` (usuários comuns) façam requisições de leitura ou escrita nos endpoints `/users/{user_id}`, resultando em `403 Forbidden`. 
->
-> **Soluções Propostas para Alinhamento com o PO/Time**:
-> * **Opção A (Recomendada)**: Remover a dependência global `require_admin_user` do roteador `/users` e aplicá-la especificamente a rotas administrativas (como `GET /users` e `DELETE /users/{user_id}`). Para `GET /users/{user_id}` e `PATCH /users/{user_id}`, permitir acesso se o usuário autenticado for o proprietário do ID (`current_user.id == user_id`) ou se for `ADMIN`.
-> * **Opção B**: Criar um endpoint dedicado e autenticado `/users/me` no backend (usando apenas `Depends(get_current_user)`) para retornar e editar o perfil do próprio usuário logado.
-> * **Opção C**: Limitar a funcionalidade de edição de perfil apenas a usuários administradores nesta Sprint.
+> A restrição global de ADMIN no roteador `/users` foi resolvida no PR #154 (Issue #147), aplicando a regra de autorização que permite que o próprio dono do perfil (`current_user.id == user_id`) atualize ou consulte seus próprios dados.
 
 ---
 
@@ -46,15 +33,17 @@ Atualmente, o backend possui rotas CRUD de usuários em [backend/app/api/users.p
 
 - **Página de Perfil (`/profile`)**:
   - Layout responsivo, utilizando os padrões de design do sistema.
-  - Carregamento de dados básicos do usuário logado (Nome, E-mail, Tipo de Conta).
+  - Carregamento inicial de dados básicos do usuário do contexto de autenticação.
+  - **Sincronização Assíncrona:** Hidratação do formulário de nome após a sessão carregar assincronamente do localStorage.
   - Formulário para alteração de Nome.
   - Validação no lado do cliente (Nome obrigatório, tamanho mínimo de 3 caracteres).
   - Redirecionamento automático para a tela de login (`/login`) caso o usuário tente acessar a rota sem estar autenticado.
 - **Feedbacks Visuais**:
-  - Estado de carregamento (*skeleton screen* ou *loading spinner*).
+  - Estado de carregamento (*loading spinner* ou *skeletons*).
   - Notificações instantâneas (toasts) indicando sucesso ou erro ao salvar dados.
 - **Integração**:
-  - Chamada HTTP para salvar modificações via `PATCH /api/users/{id}` (ou a solução de `/users/me` definida na seção *Clarification*).
+  - **Busca em tempo real:** Chamada HTTP `GET /api/v1/users/{id}` ao carregar a página para sincronizar dados locais com o banco de dados.
+  - Chamada HTTP para salvar modificações via `PATCH /api/users/{id}`.
   - Atualização do contexto global de autenticação no frontend após salvamento bem-sucedido.
 
 ### Fora de Escopo

--- a/specs/005-user-profile/tasks.md
+++ b/specs/005-user-profile/tasks.md
@@ -48,9 +48,9 @@ Para manter o histórico do Git limpo e de fácil revisão, a tarefa será divid
 
 ### Fase 4: Implementação da Interface (Green)
 
-- [ ] Criar a página `frontend/src/app/profile/page.tsx`.
-- [ ] Integrar inputs, validações e os Toasts de sucesso e erro.
-- [ ] Executar testes automatizados do frontend e garantir que todos passam (Green).
+- [x] Criar a página `frontend/src/app/profile/page.tsx`.
+- [x] Integrar inputs, validações e os Toasts de sucesso e erro.
+- [x] Executar testes automatizados do frontend e garantir que todos passam (Green).
 - [ ] **Commit 4**: `feat: implementa interface e layout da pagina de perfil`
 
 ### Fase 5: Ajustes e Revisão Final (Refactor)

--- a/specs/005-user-profile/tasks.md
+++ b/specs/005-user-profile/tasks.md
@@ -55,6 +55,6 @@ Para manter o histórico do Git limpo e de fácil revisão, a tarefa será divid
 
 ### Fase 5: Ajustes e Revisão Final (Refactor)
 
-- [ ] Testar manualmente a integração ponta a ponta com usuário `ADMIN` localmente.
-- [ ] Garantir conformidade com os linters executando `npm run lint` no frontend.
-- [ ] **Commit 5**: `test: finaliza testes de integracao e ajustes de layout`
+- [x] Testar manualmente a integração ponta a ponta com usuário `ADMIN` localmente.
+- [x] Garantir conformidade com os linters executando `npm run lint` no frontend.
+- [x] **Commit 5**: `test: finaliza testes de integracao e ajustes de layout`

--- a/specs/005-user-profile/tasks.md
+++ b/specs/005-user-profile/tasks.md
@@ -38,12 +38,12 @@ Para manter o histórico do Git limpo e de fácil revisão, a tarefa será divid
   - TC-03: Validação de input com nome curto ou vazio
   - TC-06: Cancelamento de modificações voltando ao valor original
 - [x] Rodar os testes locais do frontend para verificar a falha controlada (Red).
-- [ ] **Commit 2**: `test: adiciona testes unitarios de componente para a pagina de perfil`
+- [x] **Commit 2**: `test: adiciona testes unitarios de componente para a pagina de perfil`
 
 ### Fase 3: Infraestrutura e Serviços (Frontend)
 
-- [ ] Criar o cliente de API `frontend/src/lib/api/users.ts` com a função de atualização de perfil.
-- [ ] Modificar o `AuthContext.tsx` para incluir a função de sincronização do usuário logado na sessão ativa.
+- [x] Criar o cliente de API `frontend/src/lib/api/users.ts` com a função de atualização de perfil.
+- [x] Modificar o `AuthContext.tsx` para incluir a função de sincronização do usuário logado na sessão ativa.
 - [ ] **Commit 3**: `feat: implementa client de api e estende AuthContext para perfil`
 
 ### Fase 4: Implementação da Interface (Green)

--- a/specs/005-user-profile/tasks.md
+++ b/specs/005-user-profile/tasks.md
@@ -32,12 +32,12 @@ Para manter o histórico do Git limpo e de fácil revisão, a tarefa será divid
 
 ### Fase 2: Escrita de Testes (TDD - Red)
 
-- [ ] Criar arquivo de teste `frontend/src/app/profile/__tests__/page.test.tsx` com os cenários:
+- [x] Criar arquivo de teste `frontend/src/app/profile/__tests__/page.test.tsx` com os cenários:
   - TC-01: Redirecionamento se não autenticado
   - TC-02: Exibição de dados iniciais do usuário
   - TC-03: Validação de input com nome curto ou vazio
   - TC-06: Cancelamento de modificações voltando ao valor original
-- [ ] Rodar os testes locais do frontend para verificar a falha controlada (Red).
+- [x] Rodar os testes locais do frontend para verificar a falha controlada (Red).
 - [ ] **Commit 2**: `test: adiciona testes unitarios de componente para a pagina de perfil`
 
 ### Fase 3: Infraestrutura e Serviços (Frontend)

--- a/specs/005-user-profile/tasks.md
+++ b/specs/005-user-profile/tasks.md
@@ -1,0 +1,60 @@
+# Tasks — Tela de Perfil do Usuário
+
+Issue: #135 | Sprint 12 | Responsável: @ViniciusA05
+
+## Planejamento de Commits Atômicos
+
+Para manter o histórico do Git limpo e de fácil revisão, a tarefa será dividida nos seguintes commits atômicos:
+
+1. `docs: especifica funcionalidade de perfil de usuario #135`
+   - Contém a pasta `specs/005-user-profile/` com todos os documentos de SDD/TDD.
+2. `test: adiciona testes unitarios de componente para a pagina de perfil`
+   - Contém a implementação inicial dos testes de comportamento no frontend (Red/TDD).
+3. `feat: implementa client de api e estende AuthContext para perfil`
+   - Contém a criação do client de API e propagação da alteração do usuário no estado global.
+4. `feat: implementa interface e layout da pagina de perfil`
+   - Contém a tela `/profile`, tratamentos de erro, loading e redirecionamentos.
+5. `test: finaliza testes de integracao e ajustes de layout`
+   - Ajustes finais, correções de linting e validação de cobertura de testes.
+
+---
+
+## Detalhamento de Atividades
+
+### Fase 1: Especificação e Design (SDD)
+
+- [x] Criar `specs/005-user-profile/spec.md`
+- [x] Criar `specs/005-user-profile/plan.md`
+- [x] Criar `specs/005-user-profile/test-plan.md`
+- [x] Criar `specs/005-user-profile/tasks.md` (Esta lista)
+- [x] Criar `specs/005-user-profile/quickstart.md`
+- [x] **Commit 1**: `docs: especifica funcionalidade de perfil de usuario #135`
+
+### Fase 2: Escrita de Testes (TDD - Red)
+
+- [ ] Criar arquivo de teste `frontend/src/app/profile/__tests__/page.test.tsx` com os cenários:
+  - TC-01: Redirecionamento se não autenticado
+  - TC-02: Exibição de dados iniciais do usuário
+  - TC-03: Validação de input com nome curto ou vazio
+  - TC-06: Cancelamento de modificações voltando ao valor original
+- [ ] Rodar os testes locais do frontend para verificar a falha controlada (Red).
+- [ ] **Commit 2**: `test: adiciona testes unitarios de componente para a pagina de perfil`
+
+### Fase 3: Infraestrutura e Serviços (Frontend)
+
+- [ ] Criar o cliente de API `frontend/src/lib/api/users.ts` com a função de atualização de perfil.
+- [ ] Modificar o `AuthContext.tsx` para incluir a função de sincronização do usuário logado na sessão ativa.
+- [ ] **Commit 3**: `feat: implementa client de api e estende AuthContext para perfil`
+
+### Fase 4: Implementação da Interface (Green)
+
+- [ ] Criar a página `frontend/src/app/profile/page.tsx`.
+- [ ] Integrar inputs, validações e os Toasts de sucesso e erro.
+- [ ] Executar testes automatizados do frontend e garantir que todos passam (Green).
+- [ ] **Commit 4**: `feat: implementa interface e layout da pagina de perfil`
+
+### Fase 5: Ajustes e Revisão Final (Refactor)
+
+- [ ] Testar manualmente a integração ponta a ponta com usuário `ADMIN` localmente.
+- [ ] Garantir conformidade com os linters executando `npm run lint` no frontend.
+- [ ] **Commit 5**: `test: finaliza testes de integracao e ajustes de layout`

--- a/specs/005-user-profile/test-plan.md
+++ b/specs/005-user-profile/test-plan.md
@@ -23,6 +23,8 @@ A implementação deve conter um arquivo de testes na pasta do frontend: `fronte
 | **TC-04** | Submissão com sucesso | Alterar nome para "João Souza" e clicar em Salvar | Chamar a API de usuários com `PATCH`, atualizar o `AuthContext` com o novo nome e exibir Toast de sucesso. |
 | **TC-05** | Erro da API | Alterar nome, API retorna erro (ex: `403` ou `500`) | Exibir Toast informando o erro amigável ao usuário, mantendo o formulário habilitado. |
 | **TC-06** | Cancelamento | Editar o nome de "João Silva" para "João Santos" e clicar em Cancelar | Retornar o valor do input para o estado original ("João Silva"). |
+| **TC-07** | Hidratação assíncrona da sessão | Entrar na página com `user: null` e depois hidratar o contexto com o usuário logado | Exibir o loader na primeira renderização; após a hidratação, preencher o input de nome com o valor do contexto. |
+| **TC-08** | Busca em tempo real na API | Carregar a página `/profile` com sessão autenticada ativa | Disparar a requisição `getProfile` à API ao iniciar a página para obter dados atualizados. |
 
 ---
 

--- a/specs/005-user-profile/test-plan.md
+++ b/specs/005-user-profile/test-plan.md
@@ -1,0 +1,50 @@
+# Test Plan: Tela de Perfil do Usuário — R2
+
+**Feature**: Tela de Perfil do Usuário
+**ID da Spec**: `specs/005-user-profile`
+
+## Objetivos do Teste
+
+Garantir que a página de perfil (`/profile`) funcione corretamente sob estados de autenticação ativos/inativos, valide inputs corretamente no cliente, chame a API de usuários conforme o esperado e trate erros de API elegantemente, atualizando o contexto do usuário sem recarregar o navegador.
+
+---
+
+## 1. Testes Automatizados de Componentes (Jest + React Testing Library)
+
+A implementação deve conter um arquivo de testes na pasta do frontend: `frontend/src/app/profile/__tests__/page.test.tsx` ou similar.
+
+### Casos de Teste (Componentes)
+
+| ID | Cenário | Ações | Resultado Esperado |
+|---|---|---|---|
+| **TC-01** | Redirecionamento de não autenticado | Acessar `/profile` sem usuário logado no `AuthContext` | Chamar `router.push('/login')` imediatamente. |
+| **TC-02** | Exibição de dados iniciais | Acessar `/profile` autenticado como "João Silva" | Input do Nome pré-preenchido com "João Silva" e e-mail exibido corretamente (desabilitado). |
+| **TC-03** | Validação de input (Erro) | Digitar nome vazio ou com < 3 caracteres e tentar salvar | Exibir mensagem de validação client-side ("O nome deve conter pelo menos 3 caracteres") e bloquear submissão. |
+| **TC-04** | Submissão com sucesso | Alterar nome para "João Souza" e clicar em Salvar | Chamar a API de usuários com `PATCH`, atualizar o `AuthContext` com o novo nome e exibir Toast de sucesso. |
+| **TC-05** | Erro da API | Alterar nome, API retorna erro (ex: `403` ou `500`) | Exibir Toast informando o erro amigável ao usuário, mantendo o formulário habilitado. |
+| **TC-06** | Cancelamento | Editar o nome de "João Silva" para "João Santos" e clicar em Cancelar | Retornar o valor do input para o estado original ("João Silva"). |
+
+---
+
+## 2. Testes de Integração Manual (End-to-End)
+
+Para garantir que a integração frontend-backend esteja redonda e a segurança do backend esteja funcionando adequadamente:
+
+### Cenário 1: Fluxo de Sucesso com Usuário ADMIN
+1. Logar no CrivoAI com um usuário que possua a role `ADMIN`.
+2. Acessar a URL `/profile`.
+3. Validar se as informações de e-mail e nome correspondem ao usuário logado.
+4. Alterar o nome no input e clicar em "Salvar Alterações".
+5. Validar o surgimento do Toast de sucesso.
+6. Atualizar a página do navegador e conferir se o novo nome persiste no cabeçalho e na página de perfil.
+
+### Cenário 2: Tratamento de Erro de Autorização (COMMON User)
+1. Logar no CrivoAI com um usuário comum (`role: "COMMON"`).
+2. Acessar a URL `/profile`.
+3. Alterar o nome no formulário e tentar salvar.
+4. Validar o retorno da requisição de rede (`403 Forbidden`).
+5. Validar que o Toast de erro é disparado avisando que a operação não é permitida (caso a dependência global do backend de usuários não tenha sido ajustada ainda).
+
+### Cenário 3: Proteção de Rota
+1. Estando deslogado do sistema, tentar forçar o acesso direto à URL `http://localhost:3000/profile`.
+2. Validar que o sistema barra a entrada e redireciona o navegador para `http://localhost:3000/login`.


### PR DESCRIPTION
## 📝 Descrição
Este Pull Request implementa a interface e a lógica de visualização e edição do perfil de usuários logados (Next.js / TypeScript) no frontend do **CrivoAI** para a R2.

### 🌟 O que foi feito:
1. **Página de Perfil (`/profile`)**: Criado o Client Component [frontend/src/app/profile/page.tsx](file:///C:/Users/vinic/Desktop/MDS/2026-1-Squad07/frontend/src/app/profile/page.tsx) com layout responsivo utilizando o design system do projeto.
2. **Integração com o Design System**: Utilizados os componentes `<Button />` e `<Input />` da biblioteca Shadcn/Radix do projeto para manter a conformidade visual e de focos.
3. **Gerenciamento Reativo de Estado**: Adicionada a propriedade `key={user.id}` no formulário de perfil. Isso garante que a sub-árvore do formulário seja remontada de forma limpa assim que a sessão assíncrona carregar do `localStorage`, inicializando o estado local `name` sem gerar antipadrões de múltiplos `useEffect` e rerenders em cascata.
4. **Proteção de Rota e Concorrência**: Criada verificação assíncrona com `useRouter` e `useEffect` para redirecionar usuários não autenticados para `/login`, utilizando um temporizador de atraso de segurança de 100ms para evitar falsos redirecionamentos durante o carregamento inicial da sessão.
5. **Feedbacks Visuais e Acessibilidade (a11y)**:
   - Integrado o container `<Toaster />` do `sonner` de forma global em [AppShell.tsx](file:///C:/Users/vinic/Desktop/MDS/2026-1-Squad07/frontend/src/components/AppShell.tsx).
   - Adicionadas tags de acessibilidade semântica `aria-invalid={!!error}` e `aria-describedby` que respondem ao feedback visual dos componentes de input e leitura de tela.
6. **Especificação Técnica**: Pasta de especificações SDD/TDD adicionada em `specs/005-user-profile/` contendo spec funcional, plano de implementação técnica, test-plan, tarefas e um guia quickstart adaptado para Docker.

### ⚠️ Observação Crucial (Backend):
O salvamento de alterações para usuários de nível comum (`role: "COMMON"`) atualmente retorna `403 Forbidden` devido à dependência global `require_admin_user` aplicada ao roteador `/users` no backend em [backend/app/api/users.py](file:///C:/Users/vinic/Desktop/MDS/2026-1-Squad07/backend/app/api/users.py). 
A tela de perfil foi blindada para exibir e tratar este erro amigavelmente (exibindo Toast de erro da rede), e o backend foi intocado para manter o escopo linear desta branch de frontend. Uma issue separada de backend foi criada para resolver essa regra de autorização.

---

## 🏷️ Tipo de alteração
- [x] ✨ `feat:` Nova funcionalidade
- [x] ♻️ `refactor:` Refatoração de código (não altera as funcionalidades)
- [x] 📚 `docs:` Atualização na documentação

---

## ✅ Checklist de Revisão
- [x] O meu código segue os padrões do nosso Guia Definitivo.
- [x] Realizei uma auto-revisão detalhada do meu próprio código (Code Review aprovado sem pendências documentado no repositório).
- [x] Os meus commits são atômicos e as mensagens seguem o padrão *Conventional Commits*.
- [x] O código não gera novos conflitos de merge (verifiquei a branch base).
- [x] A alteração não introduz novos avisos (warnings) ou erros no terminal.

---

## 🧪 Testes
- [x] Criei/atualizei testes para esta funcionalidade (se aplicável).
- [x] Testei a funcionalidade localmente e tudo está funcionando perfeitamente.

### 💻 Como Testar:
1. **Testes Unitários (Jest)**:
   Acesse a pasta `frontend` e rode o Jest:
   ```powershell
   npm run test
   ```
   *Resultado Esperado*: As 6 test suites devem passar com 100% de sucesso (40 testes ativos).
2. **Ambiente E2E (Docker)**:
   Suba o banco e a API com Docker na raiz:
   ```powershell
   docker compose up -d --build
   ```
   No host local, inicie o frontend:
   ```powershell
   cd frontend
   npm run dev
   ```
   Acesse `http://localhost:3000/profile` logado com uma conta de nível `ADMIN` para validar o Happy Path de alteração de nome com persistência no banco e disparo dos Toasts.

---

## 🖼️ Capturas de tela ou Vídeos (Se aplicável)
*(Insira a captura de tela da página de perfil e a notificação de Toast de sucesso/validação)*
