### PR TITLE
Fix/issue 147 autorizacao perfil usuario

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 
-from app.api.dependencies import require_admin_user
+from app.api.dependencies import get_current_user, require_admin_user
 from app.db.client import db
 from app.models.user import UserCreateRequest, UserResponse, UserUpdateRequest
 from app.services.security import hash_password
@@ -8,11 +8,23 @@ from app.services.security import hash_password
 router = APIRouter(
     prefix="/users",
     tags=["users"],
-    dependencies=[Depends(require_admin_user)],
 )
 
 
-@router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+def ensure_profile_access(current_user, user_id: str) -> None:
+    if current_user.id != user_id and current_user.role != "ADMIN":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Apenas o proprio usuario ou administradores podem acessar este perfil.",
+        )
+
+
+@router.post(
+    "",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_admin_user)],
+)
 async def create_user(user: UserCreateRequest):
     """Cria um usuario com senha hasheada."""
     existing_user = await db.user.find_unique(where={"email": user.email})
@@ -28,15 +40,21 @@ async def create_user(user: UserCreateRequest):
     return await db.user.create(data=data)
 
 
-@router.get("", response_model=list[UserResponse])
+@router.get(
+    "",
+    response_model=list[UserResponse],
+    dependencies=[Depends(require_admin_user)],
+)
 async def list_users():
     """Lista todos os usuarios."""
     return await db.user.find_many()
 
 
 @router.get("/{user_id}", response_model=UserResponse)
-async def get_user(user_id: str):
+async def get_user(user_id: str, current_user=Depends(get_current_user)):
     """Busca um usuario pelo id."""
+    ensure_profile_access(current_user, user_id)
+
     user = await db.user.find_unique(where={"id": user_id})
     if not user:
         raise HTTPException(
@@ -48,8 +66,14 @@ async def get_user(user_id: str):
 
 
 @router.patch("/{user_id}", response_model=UserResponse)
-async def update_user(user_id: str, user: UserUpdateRequest):
+async def update_user(
+    user_id: str,
+    user: UserUpdateRequest,
+    current_user=Depends(get_current_user),
+):
     """Atualiza parcialmente um usuario."""
+    ensure_profile_access(current_user, user_id)
+
     existing_user = await db.user.find_unique(where={"id": user_id})
     if not existing_user:
         raise HTTPException(
@@ -75,7 +99,11 @@ async def update_user(user_id: str, user: UserUpdateRequest):
     return await db.user.update(where={"id": user_id}, data=data)
 
 
-@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_admin_user)],
+)
 async def delete_user(user_id: str):
     """Remove um usuario pelo id."""
     existing_user = await db.user.find_unique(where={"id": user_id})

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -85,6 +85,12 @@ async def update_user(
     if not data:
         return existing_user
 
+    if "role" in data and current_user.role != "ADMIN":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Apenas administradores podem alterar a role de um usuario.",
+        )
+
     if "email" in data:
         user_with_email = await db.user.find_unique(where={"email": data["email"]})
         if user_with_email and user_with_email.id != user_id:

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -297,6 +297,18 @@ def test_update_user_permite_usuario_comum_atualizar_proprio_perfil(monkeypatch)
     assert fake_user_delegate.updated_data == {"name": "Maria Souza"}
 
 
+def test_update_user_rejeita_usuario_comum_alterando_propria_role(monkeypatch):
+    common_user = make_user(role="COMMON")
+    fake_user_delegate = FakeUserDelegate([common_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.patch("/users/user-123", json={"role": "ADMIN"})
+
+    assert response.status_code == 403
+    assert fake_user_delegate.updated_data is None
+
+
 def test_update_user_rejeita_usuario_comum_atualizando_outro_perfil(monkeypatch):
     common_user = make_user(user_id="user-123", role="COMMON")
     other_user = make_user(user_id="user-456", email="ana@example.com")

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -97,8 +97,10 @@ class FakeUserDelegate:
 @pytest.fixture(autouse=True)
 def admin_dependency_override():
     app.dependency_overrides[users.require_admin_user] = lambda: make_user(role="ADMIN")
+    app.dependency_overrides[users.get_current_user] = lambda: make_user(role="ADMIN")
     yield
     app.dependency_overrides.pop(users.require_admin_user, None)
+    app.dependency_overrides.pop(users.get_current_user, None)
 
 
 def test_list_users_rejeita_requisicao_sem_token():
@@ -202,6 +204,30 @@ def test_get_user_retorna_404_quando_nao_encontra(monkeypatch):
     assert response.status_code == 404
 
 
+def test_get_user_permite_usuario_comum_consultar_proprio_perfil(monkeypatch):
+    common_user = make_user(role="COMMON")
+    fake_user_delegate = FakeUserDelegate([common_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.get("/users/user-123")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "user-123"
+
+
+def test_get_user_rejeita_usuario_comum_consultando_outro_perfil(monkeypatch):
+    common_user = make_user(user_id="user-123", role="COMMON")
+    other_user = make_user(user_id="user-456", email="ana@example.com")
+    fake_user_delegate = FakeUserDelegate([common_user, other_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.get("/users/user-456")
+
+    assert response.status_code == 403
+
+
 def test_update_user_atualiza_somente_campos_enviados(monkeypatch):
     fake_user_delegate = FakeUserDelegate([make_user()])
     monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
@@ -255,6 +281,31 @@ def test_update_user_rejeita_campos_nulos(monkeypatch):
     response = client.patch("/users/user-123", json={"password": None})
 
     assert response.status_code == 422
+    assert fake_user_delegate.updated_data is None
+
+
+def test_update_user_permite_usuario_comum_atualizar_proprio_perfil(monkeypatch):
+    common_user = make_user(role="COMMON")
+    fake_user_delegate = FakeUserDelegate([common_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.patch("/users/user-123", json={"name": "Maria Souza"})
+
+    assert response.status_code == 200
+    assert fake_user_delegate.updated_data == {"name": "Maria Souza"}
+
+
+def test_update_user_rejeita_usuario_comum_atualizando_outro_perfil(monkeypatch):
+    common_user = make_user(user_id="user-123", role="COMMON")
+    other_user = make_user(user_id="user-456", email="ana@example.com")
+    fake_user_delegate = FakeUserDelegate([common_user, other_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.patch("/users/user-456", json={"name": "Ana Souza"})
+
+    assert response.status_code == 403
     assert fake_user_delegate.updated_data is None
 
 

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -105,6 +105,7 @@ def admin_dependency_override():
 
 def test_list_users_rejeita_requisicao_sem_token():
     app.dependency_overrides.pop(users.require_admin_user, None)
+    app.dependency_overrides.pop(users.get_current_user, None)
 
     response = client.get("/users")
 

--- a/backend/tests/unit/test_users.py
+++ b/backend/tests/unit/test_users.py
@@ -21,6 +21,7 @@ def admin_dependency_override():
 
 def test_list_users_rejeita_requisicao_sem_token():
     app.dependency_overrides.pop(users.require_admin_user, None)
+    app.dependency_overrides.pop(users.get_current_user, None)
 
     response = client.get("/users")
 

--- a/backend/tests/unit/test_users.py
+++ b/backend/tests/unit/test_users.py
@@ -13,8 +13,10 @@ client = TestClient(app)
 @pytest.fixture(autouse=True)
 def admin_dependency_override():
     app.dependency_overrides[users.require_admin_user] = lambda: make_user(role="ADMIN")
+    app.dependency_overrides[users.get_current_user] = lambda: make_user(role="ADMIN")
     yield
     app.dependency_overrides.pop(users.require_admin_user, None)
+    app.dependency_overrides.pop(users.get_current_user, None)
 
 
 def test_list_users_rejeita_requisicao_sem_token():
@@ -118,6 +120,30 @@ def test_get_user_retorna_404_quando_nao_encontra(monkeypatch):
     assert response.status_code == 404
 
 
+def test_get_user_permite_usuario_comum_consultar_proprio_perfil(monkeypatch):
+    common_user = make_user(role="COMMON")
+    fake_user_delegate = FakeUserDelegate([common_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.get("/users/user-123")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "user-123"
+
+
+def test_get_user_rejeita_usuario_comum_consultando_outro_perfil(monkeypatch):
+    common_user = make_user(user_id="user-123", role="COMMON")
+    other_user = make_user(user_id="user-456", email="ana@example.com")
+    fake_user_delegate = FakeUserDelegate([common_user, other_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.get("/users/user-456")
+
+    assert response.status_code == 403
+
+
 def test_update_user_atualiza_somente_campos_enviados(monkeypatch):
     fake_user_delegate = FakeUserDelegate([make_user()])
     monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
@@ -171,6 +197,31 @@ def test_update_user_rejeita_campos_nulos(monkeypatch):
     response = client.patch("/users/user-123", json={"password": None})
 
     assert response.status_code == 422
+    assert fake_user_delegate.updated_data is None
+
+
+def test_update_user_permite_usuario_comum_atualizar_proprio_perfil(monkeypatch):
+    common_user = make_user(role="COMMON")
+    fake_user_delegate = FakeUserDelegate([common_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.patch("/users/user-123", json={"name": "Maria Souza"})
+
+    assert response.status_code == 200
+    assert fake_user_delegate.updated_data == {"name": "Maria Souza"}
+
+
+def test_update_user_rejeita_usuario_comum_atualizando_outro_perfil(monkeypatch):
+    common_user = make_user(user_id="user-123", role="COMMON")
+    other_user = make_user(user_id="user-456", email="ana@example.com")
+    fake_user_delegate = FakeUserDelegate([common_user, other_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.patch("/users/user-456", json={"name": "Ana Souza"})
+
+    assert response.status_code == 403
     assert fake_user_delegate.updated_data is None
 
 

--- a/backend/tests/unit/test_users.py
+++ b/backend/tests/unit/test_users.py
@@ -213,6 +213,18 @@ def test_update_user_permite_usuario_comum_atualizar_proprio_perfil(monkeypatch)
     assert fake_user_delegate.updated_data == {"name": "Maria Souza"}
 
 
+def test_update_user_rejeita_usuario_comum_alterando_propria_role(monkeypatch):
+    common_user = make_user(role="COMMON")
+    fake_user_delegate = FakeUserDelegate([common_user])
+    monkeypatch.setattr(users, "db", SimpleNamespace(user=fake_user_delegate))
+    app.dependency_overrides[users.get_current_user] = lambda: common_user
+
+    response = client.patch("/users/user-123", json={"role": "ADMIN"})
+
+    assert response.status_code == 403
+    assert fake_user_delegate.updated_data is None
+
+
 def test_update_user_rejeita_usuario_comum_atualizando_outro_perfil(monkeypatch):
     common_user = make_user(user_id="user-123", role="COMMON")
     other_user = make_user(user_id="user-456", email="ana@example.com")


### PR DESCRIPTION
## 📝 Descrição

Corrige a autorização das rotas de perfil de usuário no backend.

Antes, o roteador `/users` aplicava `require_admin_user` globalmente, impedindo usuários comuns de consultar ou atualizar o próprio perfil via `GET /users/{id}` e `PATCH /users/{id}`. Agora, essas rotas permitem acesso ao próprio usuário autenticado ou a administradores.

As rotas administrativas continuam restritas a usuários `ADMIN`:
- `POST /users`
- `GET /users`
- `DELETE /users/{user_id}`

Também foram adicionados testes cobrindo:
- usuário comum consultando o próprio perfil;
- usuário comum atualizando o próprio perfil;
- bloqueio de usuário comum tentando acessar perfil de outro usuário.

Closes #147

## 🏷️ Tipo de alteração
- [ ] ✨ `feat:` Nova funcionalidade
- [x] 🐛 `bugfix:` Correção de um erro
- [ ] ♻️ `refactor:` Refatoração de código (não altera as funcionalidades)
- [ ] 📚 `docs:` Atualização na documentação
- [ ] 🔧 `chore:` Tarefas de manutenção (dependências, configurações, etc.)

## ✅ Checklist de Revisão
- [x] O meu código segue os padrões do nosso Guia Definitivo.
- [x] Realizei uma auto-revisão detalhada do meu próprio código.
- [x] Os meus commits são atômicos e as mensagens seguem o padrão *Conventional Commits*.
- [x] O código não gera novos conflitos de merge (verifiquei a branch base).
- [x] A alteração não introduz novos avisos (warnings) ou erros no terminal.

## 🧪 Testes
- [x] Criei/atualizei testes para esta funcionalidade (se aplicável).
- [x] Testei a funcionalidade localmente e tudo está funcionando perfeitamente.

## 🖼️ Capturas de tela ou Vídeos (Se aplicável)

Não aplicável.