### PR TITLE
docs: adiciona CODE_OF_CONDUCT e SECURITY (community standards)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Código de Conduta do Contribuidor
+
+## Nosso Compromisso
+
+Nós, como membros, contribuidores e líderes, nos comprometemos a fazer da participação
+em nossa comunidade uma experiência livre de assédio para todas as pessoas,
+independentemente de idade, tamanho corporal, deficiência aparente ou não aparente,
+etnia, características sexuais, identidade e expressão de gênero, nível de experiência,
+educação, condição socioeconômica, nacionalidade, aparência pessoal, raça, religião ou
+identidade e orientação sexual.
+
+Comprometemo-nos a agir e interagir de maneiras que contribuam para uma comunidade
+aberta, acolhedora, diversa, inclusiva e saudável.
+
+## Nossos Padrões
+
+Exemplos de comportamento que contribuem para um ambiente positivo em nossa comunidade
+incluem:
+
+* Demonstrar empatia e gentileza com outras pessoas
+* Respeitar opiniões, pontos de vista e experiências divergentes
+* Dar e receber feedback construtivo com elegância
+* Assumir responsabilidade, pedir desculpas às pessoas afetadas por nossos erros e
+  aprender com a experiência
+* Focar no que é melhor não apenas para nós individualmente, mas para a comunidade
+  como um todo
+
+Exemplos de comportamento inaceitável incluem:
+
+* O uso de linguagem ou imagens sexualizadas e atenção ou investidas sexuais de
+  qualquer tipo
+* Comentários ofensivos (*trolling*), insultuosos ou depreciativos, e ataques pessoais
+  ou políticos
+* Assédio público ou privado
+* Publicar informações privadas de outras pessoas, como endereço físico ou de e-mail,
+  sem sua permissão explícita
+* Qualquer outra conduta que possa ser razoavelmente considerada inadequada em um
+  ambiente profissional
+
+## Responsabilidades de Aplicação
+
+Os líderes da comunidade são responsáveis por esclarecer e fazer cumprir nossos padrões
+de comportamento aceitável e tomarão ações corretivas apropriadas e justas em resposta a
+qualquer comportamento que considerem impróprio, ameaçador, ofensivo ou prejudicial.
+
+Os líderes da comunidade têm o direito e a responsabilidade de remover, editar ou
+rejeitar comentários, *commits*, código, edições de *wiki*, *issues* e outras
+contribuições que não estejam alinhadas a este Código de Conduta, e comunicarão os
+motivos das decisões de moderação quando apropriado.
+
+## Escopo
+
+Este Código de Conduta se aplica a todos os espaços da comunidade e também quando uma
+pessoa está representando oficialmente a comunidade em espaços públicos. Exemplos de
+representação da nossa comunidade incluem o uso de um endereço de e-mail oficial,
+publicações em contas oficiais de redes sociais ou atuação como representante designado
+em um evento on-line ou presencial.
+
+## Aplicação
+
+Casos de comportamento abusivo, de assédio ou de qualquer outra forma inaceitável podem
+ser reportados aos líderes da comunidade responsáveis pela aplicação por meio do e-mail
+**jonathancarpanedaj@gmail.com** ou pela abertura de contato direto com os mantenedores
+do Squad 07. Todas as reclamações serão analisadas e investigadas de forma rápida e
+justa.
+
+Todos os líderes da comunidade são obrigados a respeitar a privacidade e a segurança de
+quem reportar qualquer incidente.
+
+## Diretrizes de Aplicação
+
+Os líderes da comunidade seguirão estas Diretrizes de Impacto na Comunidade para
+determinar as consequências de qualquer ação que considerem violação deste Código de
+Conduta:
+
+### 1. Correção
+
+**Impacto na Comunidade**: Uso de linguagem inadequada ou outro comportamento considerado
+não profissional ou indesejado na comunidade.
+
+**Consequência**: Uma advertência privada e por escrito dos líderes da comunidade,
+esclarecendo a natureza da violação e explicando por que o comportamento foi inadequado.
+Um pedido de desculpas público pode ser solicitado.
+
+### 2. Advertência
+
+**Impacto na Comunidade**: Uma violação por meio de um único incidente ou de uma série
+de ações.
+
+**Consequência**: Uma advertência com consequências para comportamento contínuo. Nenhuma
+interação com as pessoas envolvidas, incluindo interação não solicitada com aqueles que
+aplicam o Código de Conduta, por um período determinado. Isso inclui evitar interações em
+espaços da comunidade, bem como em canais externos, como redes sociais. A violação desses
+termos pode levar a um banimento temporário ou permanente.
+
+### 3. Banimento Temporário
+
+**Impacto na Comunidade**: Uma violação grave dos padrões da comunidade, incluindo
+comportamento inadequado contínuo.
+
+**Consequência**: Um banimento temporário de qualquer tipo de interação ou comunicação
+pública com a comunidade por um período determinado. Nenhuma interação pública ou privada
+com as pessoas envolvidas, incluindo interação não solicitada com aqueles que aplicam o
+Código de Conduta, é permitida durante esse período. A violação desses termos pode levar
+a um banimento permanente.
+
+### 4. Banimento Permanente
+
+**Impacto na Comunidade**: Demonstrar um padrão de violação dos padrões da comunidade,
+incluindo comportamento inadequado contínuo, assédio a uma pessoa ou agressão ou
+depreciação de grupos de pessoas.
+
+**Consequência**: Um banimento permanente de qualquer tipo de interação pública dentro da
+comunidade.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant][homepage], versão 2.1,
+disponível em
+https://www.contributor-covenant.org/pt-br/version/2/1/code_of_conduct.html.
+
+As Diretrizes de Impacto na Comunidade foram inspiradas na
+[escada de aplicação do código de conduta da Mozilla][mozilla-coc].
+
+Para respostas a perguntas comuns sobre este código de conduta, consulte as FAQ em
+https://www.contributor-covenant.org/faq. Traduções estão disponíveis em
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla-coc]: https://github.com/mozilla/diversity

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Política de Segurança
+
+A segurança do CrivoAI é uma prioridade do Squad 07. Esta política descreve como
+reportar vulnerabilidades e o que esperar após o envio de um relatório.
+
+## Versões Suportadas
+
+Por se tratar de um projeto acadêmico em desenvolvimento ativo, apenas a versão mais
+recente do código nas branches `main` e `dev` recebe correções de segurança.
+
+| Versão            | Suportada          |
+| ----------------- | ------------------ |
+| `main` (estável)  | :white_check_mark: |
+| `dev`             | :white_check_mark: |
+| Demais branches   | :x:                |
+
+## Como Reportar uma Vulnerabilidade
+
+**Não abra uma issue pública para relatar vulnerabilidades de segurança.** Divulgar
+uma falha publicamente antes de sua correção pode expor os usuários a riscos.
+
+Em vez disso, utilize um dos canais privados abaixo:
+
+1. **GitHub Security Advisories (recomendado):** acesse a aba
+   [**Security**](https://github.com/unb-mds/2026-1-Squad07/security/advisories) do
+   repositório e clique em *"Report a vulnerability"*. Esse canal mantém o relatório
+   privado até que a correção esteja disponível.
+2. **E-mail:** envie os detalhes para **jonathancarpanedaj@gmail.com**, com o assunto
+   iniciando por `[SEGURANÇA] CrivoAI`.
+
+### Informações que ajudam na análise
+
+Para acelerar a investigação, inclua no relatório, sempre que possível:
+
+- Uma descrição clara da vulnerabilidade e do seu impacto potencial;
+- Os passos para reproduzir o problema (endpoint, requisição, payload ou tela afetada);
+- A versão, branch ou commit em que a falha foi identificada;
+- Provas de conceito, capturas de tela ou logs relevantes;
+- Qualquer sugestão de mitigação ou correção, caso tenha.
+
+## O que Esperar Após o Relatório
+
+- **Confirmação de recebimento:** em até **5 dias úteis**.
+- **Avaliação inicial e triagem:** em até **10 dias úteis**, informaremos se a falha foi
+  confirmada e qual a severidade atribuída.
+- **Correção:** vulnerabilidades confirmadas serão corrigidas em uma branch dedicada e
+  integradas via Pull Request para `dev` e, em seguida, `main`.
+- **Divulgação:** após a correção, os créditos podem ser atribuídos à pessoa que reportou,
+  caso ela deseje.
+
+Pedimos que a divulgação seja **responsável**: aguarde a correção antes de tornar a
+vulnerabilidade pública.
+
+## Boas Práticas de Segurança no Projeto
+
+Para contribuidores, reforçamos alguns cuidados básicos:
+
+- **Nunca** faça commit de segredos (senhas, tokens, chaves de API ou strings de conexão).
+  Utilize variáveis de ambiente e o arquivo `.env.example` como referência.
+- Mantenha as dependências do backend (`requirements.txt`) e do frontend
+  (`package.json`) atualizadas.
+- Valide e sanitize entradas de usuário, especialmente nos endpoints de submissão de
+  textos legislativos.
+- Siga o princípio do menor privilégio ao configurar acessos ao banco de dados e a
+  serviços externos.
+
+Agradecemos a colaboração de todas as pessoas que ajudam a manter o CrivoAI seguro.


### PR DESCRIPTION
## Objetivo

Completa o checklist de **Community Standards** do GitHub, adicionando os dois arquivos que faltavam no repositorio.

## O que foi feito

- `CODE_OF_CONDUCT.md` — Codigo de Conduta baseado no [Contributor Covenant 2.1](https://www.contributor-covenant.org/pt-br/version/2/1/code_of_conduct.html), em PT-BR.
- `SECURITY.md` — Politica de Seguranca em PT-BR, com instrucoes de como reportar vulnerabilidades (GitHub Security Advisories + e-mail), prazos de resposta e boas praticas.

## Notas

- Ambos os arquivos estao na raiz do repositorio, onde o GitHub os detecta automaticamente.
- PR isolado, sem misturar com outros arquivos.
- O `CONTRIBUTING.md` (terceiro item do checklist) ja existe no repositorio.

## Como validar

Apos o merge, verificar em Insights → Community Standards que o checklist exibe 100%: https://github.com/unb-mds/2026-1-Squad07/community