### PR TITLE
docs: adiciona CODE_OF_CONDUCT e SECURITY (community standards) #124

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,139 @@
+# Código de Conduta para Contribuidores
+
+## Nosso Compromisso
+
+Nós, como integrantes, contribuidores e líderes, nos comprometemos a fazer da
+participação em nossa comunidade uma experiência livre de assédio para todos,
+independentemente de idade, tamanho corporal, deficiência visível ou invisível,
+etnia, características sexuais, identidade e expressão de gênero, nível de
+experiência, educação, status socioeconômico, nacionalidade, aparência pessoal,
+raça, religião, ou identidade e orientação sexual.
+
+Comprometemo-nos a agir e interagir de maneiras que contribuam para uma
+comunidade aberta, acolhedora, diversificada, inclusiva e saudável.
+
+## Nossos Padrões
+
+Exemplos de comportamentos que contribuem para um ambiente positivo para a
+nossa comunidade incluem:
+
+* Demonstrar empatia e gentileza para com as outras pessoas
+* Respeitar opiniões, pontos de vista e experiências divergentes
+* Dar e receber feedbacks construtivos com elegância
+* Assumir responsabilidade e pedir desculpas aos que foram afetados por nossos
+  erros, aprendendo com a experiência
+* Focar no que é melhor não apenas para nós individualmente, mas para a
+  comunidade como um todo
+
+Exemplos de comportamentos inaceitáveis incluem:
+
+* O uso de linguagem ou imagens sexualizadas, e investidas ou avanços sexuais
+  de qualquer tipo
+* Comentários insultuosos ou depreciativos *(trolling)*, e ataques pessoais ou
+  de cunho político
+* Assédio público ou privado
+* Publicar informações privadas de outras pessoas, como um endereço físico ou
+  de e-mail, sem permissão explícita
+* Qualquer outra conduta que possa ser razoavelmente considerada inapropriada
+  em um ambiente profissional
+
+## Aplicação das Responsabilidades
+
+Os líderes da comunidade são responsáveis por esclarecer e fazer cumprir nossos
+padrões de comportamento aceitável e tomarão ações corretivas apropriadas e
+justas em resposta a qualquer comportamento que considerarem impróprio,
+ameaçador, ofensivo ou prejudicial.
+
+Os líderes da comunidade têm o direito e a responsabilidade de remover, editar
+ou rejeitar comentários, *commits*, código, edições de páginas de *wiki*,
+*issues* e outras contribuições que não estejam alinhadas a este Código de
+Conduta, e comunicarão os motivos para decisões de moderação quando for
+apropriado.
+
+## Escopo
+
+Este Código de Conduta se aplica em todos os espaços da comunidade e também se
+aplica quando um indivíduo estiver representando oficialmente a comunidade em
+espaços públicos. Exemplos de representação da nossa comunidade incluem o uso de
+um endereço de e-mail oficial, postagens por meio de uma conta oficial de mídia
+social, ou atuação como representante designado em um evento on-line ou
+off-line.
+
+## Aplicação
+
+Casos de comportamento abusivo, de assédio ou inaceitável podem ser reportados
+de forma privada aos líderes da comunidade responsáveis pela aplicação deste
+código. No caso do **CrivoAI**, as denúncias devem ser encaminhadas à equipe
+mantenedora (Squad 07) por meio do recurso de contato privado do GitHub
+(aba **Security → Report a vulnerability**, que aceita relatos confidenciais) ou
+diretamente a um dos mantenedores do repositório.
+
+Todas as queixas serão analisadas e investigadas com rapidez e justiça.
+
+Todos os líderes da comunidade são obrigados a respeitar a privacidade e a
+segurança de quem reportar qualquer incidente.
+
+## Diretrizes de Aplicação
+
+Os líderes da comunidade seguirão estas Diretrizes de Impacto na Comunidade para
+determinar as consequências de qualquer ação que considerem como uma violação
+deste Código de Conduta:
+
+### 1. Correção
+
+**Impacto na Comunidade**: O uso de linguagem imprópria ou outro comportamento
+considerado não profissional ou indesejado na comunidade.
+
+**Consequência**: Uma advertência por escrito e em particular vinda dos líderes
+da comunidade, esclarecendo a natureza da violação e explicando o motivo pelo
+qual o comportamento era inadequado. Um pedido de desculpas público pode ser
+solicitado.
+
+### 2. Aviso
+
+**Impacto na Comunidade**: Uma violação por meio de um incidente único ou por
+uma série de ações.
+
+**Consequência**: Uma advertência com consequências para comportamentos
+continuados. Nenhuma interação com as pessoas envolvidas, incluindo interação
+não solicitada com aqueles que aplicam o Código de Conduta, durante um período
+de tempo determinado. Isto inclui evitar interações em espaços da comunidade,
+assim como em canais externos, como as redes sociais. A violação destes termos
+pode levar a um banimento temporário ou permanente.
+
+### 3. Banimento Temporário
+
+**Impacto na Comunidade**: Uma violação grave dos padrões da comunidade,
+incluindo comportamento inadequado contínuo.
+
+**Consequência**: Um banimento temporário de qualquer tipo de interação ou
+comunicação pública com a comunidade durante um intervalo de tempo determinado.
+Nenhuma interação pública ou privada com as pessoas envolvidas, incluindo
+interações não solicitadas com aqueles que aplicam o Código de Conduta, é
+permitida durante este período. A violação destes termos pode levar a um
+banimento permanente.
+
+### 4. Banimento Permanente
+
+**Impacto na Comunidade**: Demonstrar um padrão de violação dos padrões da
+comunidade, incluindo comportamento inadequado contínuo, assédio a um indivíduo,
+ou agressão ou depreciação de classes de indivíduos.
+
+**Consequência**: Um banimento permanente de qualquer tipo de interação pública
+dentro da comunidade.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant][homepage],
+versão 2.1, disponível em
+https://www.contributor-covenant.org/pt-br/version/2/1/code_of_conduct.html.
+
+As Diretrizes de Impacto na Comunidade foram inspiradas na
+[escada de aplicação do código de conduta da Mozilla][Mozilla CoC].
+
+Para obter respostas a perguntas comuns sobre este código de conduta, consulte a
+FAQ em https://www.contributor-covenant.org/faq. As traduções estão disponíveis
+em https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Política de Segurança
+
+A segurança do **CrivoAI** é uma prioridade para o Squad 07. Agradecemos a
+colaboração da comunidade na identificação e na divulgação responsável de
+vulnerabilidades.
+
+## Versões Suportadas
+
+Por se tratar de um projeto acadêmico em desenvolvimento ativo (disciplina de
+Métodos de Desenvolvimento de Software — UnB/FGA), o suporte de segurança é
+fornecido apenas para a versão mais recente do código presente nas branches
+`main` e `dev`.
+
+| Versão            | Suporte            |
+| ----------------- | ------------------ |
+| `main` (estável)  | :white_check_mark: |
+| `dev`             | :white_check_mark: |
+| Demais branches   | :x:                |
+
+## Como Reportar uma Vulnerabilidade
+
+**Não abra uma _issue_ pública para relatar vulnerabilidades de segurança.**
+Issues públicas podem expor o problema antes que ele seja corrigido, colocando
+os usuários em risco.
+
+Em vez disso, utilize o canal privado de relato do GitHub:
+
+1. Acesse a página principal do repositório em
+   [unb-mds/2026-1-Squad07](https://github.com/unb-mds/2026-1-Squad07).
+2. Vá até a aba **Security**.
+3. Clique em **Report a vulnerability** (Private Vulnerability Reporting).
+4. Preencha o formulário com o máximo de detalhes possível.
+
+Caso o relato privado não esteja disponível, entre em contato diretamente com um
+dos mantenedores do repositório (Squad 07).
+
+### Informações úteis no relato
+
+Para nos ajudar a entender e resolver o problema rapidamente, inclua, sempre que
+possível:
+
+* Uma descrição clara da vulnerabilidade e do seu impacto potencial.
+* Passos detalhados para reproduzir o problema (*proof of concept*).
+* A versão, branch ou *commit* afetado.
+* Qualquer sugestão de mitigação ou correção, se houver.
+
+## Nosso Compromisso
+
+Ao receber um relato de vulnerabilidade, o Squad 07 buscará, na medida da
+disponibilidade da equipe:
+
+* **Confirmar o recebimento** do relato assim que possível.
+* **Avaliar e validar** a vulnerabilidade, mantendo quem reportou informado
+  sobre o andamento sempre que houver novidades.
+* **Trabalhar em uma correção** com prioridade compatível com a gravidade do
+  problema e com o cronograma do projeto.
+* **Manter a confidencialidade** do relato até que a correção seja publicada.
+
+> ℹ️ Por ser um projeto acadêmico, mantido por estudantes durante a disciplina,
+> os prazos de resposta podem variar conforme o calendário das sprints e a
+> disponibilidade do time. Não há garantia de SLA, mas faremos o possível para
+> tratar cada relato com responsabilidade.
+
+Pedimos que quem reportar uma vulnerabilidade conceda um prazo razoável para a
+correção antes de qualquer divulgação pública.
+
+Agradecemos a sua contribuição para tornar o CrivoAI mais seguro. 🔒


### PR DESCRIPTION
## Objetivo

Completa o checklist de **Community Standards** do GitHub, adicionando os dois arquivos que faltavam (issue #124).

## O que foi feito

- `CODE_OF_CONDUCT.md` — Codigo de Conduta baseado no [Contributor Covenant 2.1](https://www.contributor-covenant.org/pt-br/version/2/1/code_of_conduct.html), em PT-BR.
- `SECURITY.md` — Politica de Seguranca em PT-BR, com instrucoes de como reportar vulnerabilidades, prazos de resposta e boas praticas.

## Notas

- Ambos os arquivos na raiz do repositorio, onde o GitHub os detecta automaticamente.
- O `CONTRIBUTING.md` (terceiro item do checklist) ja existe no repositorio.
- O checklist so refletira 100% apos os arquivos chegarem na branch default (`main`).

## Como validar

Verificar em Insights → Community Standards: https://github.com/unb-mds/2026-1-Squad07/community

Closes #124