### PR TITLE
docs+fix: publicar modelo LegalBERT no HF e documentar deploy (MODEL_NAME/HF_TOKEN)

### DIFF
--- a/backend/scripts/upload_model.py
+++ b/backend/scripts/upload_model.py
@@ -6,7 +6,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 try:
-    from huggingface_hub import HfApi
+    from huggingface_hub import HfApi, get_token
 except ImportError:
     print(
         "Erro: A biblioteca huggingface-hub não está instalada. Execute: pip install huggingface-hub"
@@ -34,24 +34,37 @@ def main():
             "Digite o ID do repositório no Hugging Face (ex: seu-usuario/seu-modelo): "
         ).strip()
 
-    token = os.getenv("HF_TOKEN")
-    if not token:
+    # Ordem de resolução do token: env HF_TOKEN -> login em cache (hf auth login)
+    # -> prompt interativo (último recurso). Assim o upload roda sem expor o
+    # token de escrita no histórico do shell quando já se fez `hf auth login`.
+    token = os.getenv("HF_TOKEN") or get_token()
+    if not token and sys.stdin.isatty():
         token = input(
             "Digite seu token de escrita do Hugging Face (HF Write Token): "
         ).strip()
 
     if not repo_id or not token:
         print("Erro: O ID do repositório e o token do Hugging Face são obrigatórios.")
+        print("Faça `hf auth login` (ou defina HF_TOKEN) antes de rodar o upload.")
         sys.exit(1)
+
+    # Repositório privado por padrão (modelo experimental / dado institucional).
+    # Defina HF_PRIVATE=false explicitamente para publicá-lo aberto.
+    private = os.getenv("HF_PRIVATE", "true").strip().lower() not in (
+        "false",
+        "0",
+        "no",
+    )
 
     api = HfApi(token=token)
 
     try:
-        print(f"Verificando / Criando o repositório {repo_id}...")
+        print(f"Verificando / Criando o repositório {repo_id} (privado={private})...")
         api.create_repo(
             repo_id=repo_id,
             repo_type="model",
             exist_ok=True,
+            private=private,
         )
 
         print(

--- a/docs/dev/deploy.md
+++ b/docs/dev/deploy.md
@@ -59,6 +59,36 @@ Estas chaves são cadastradas no painel seguro de cada plataforma:
   * `GEMINI_API_KEY`: Sua chave de API do Google Gemini para a geração dos resumos automáticos.
   * `AUTH_SECRET_KEY`: Uma sequência de caracteres criptograficamente segura para a criptografia dos tokens JWT de autenticação.
   * `ACCESS_TOKEN_EXPIRE_MINUTES`: Tempo de expiração do token de sessão (ex: `60` minutos).
+  * `MODEL_NAME`: ID do repositório do modelo fine-tunado no Hugging Face (ex: `usuario/legalbertpt-crivoai`). **Sem esta variável**, o backend cai no modelo base (`raquelsilveira/legalbertpt_fp`) com cabeça de classificação aleatória e os scores ficam sem sentido. Veja a seção "Publicação do Modelo".
+  * `HF_TOKEN`: Token de leitura do Hugging Face — **obrigatório** porque o repositório do modelo é privado; sem ele o download em runtime falha com 401. (Um token de leitura basta no Render; use um de escrita só na hora do upload.)
+
+---
+
+## 🧠 Publicação do Modelo (LegalBERT-pt fine-tunado)
+
+Os pesos do modelo (`backend/app/models/fine_tuned_legalbert/`, ~435 MB) **não são versionados no git** (`.gitignore`) — grandes demais e mutáveis a cada treino. Portanto o merge do código **não** leva o modelo junto; ele precisa ser publicado separadamente e baixado pelo backend em runtime.
+
+### Fluxo de publicação (após treinar)
+
+1. Autentique-se no Hugging Face na sua máquina (o token **nunca** vai pro git nem pro chat):
+
+   ```bash
+   hf auth login   # ou: huggingface-cli login
+   ```
+
+2. Rode o script de upload apontando para um repositório **privado**:
+
+   ```bash
+   HF_REPO_ID="usuario/legalbertpt-crivoai" python backend/scripts/upload_model.py
+   ```
+
+   O script cria o repo (se não existir) e envia todos os arquivos de `fine_tuned_legalbert/`.
+
+3. No Render, configure `MODEL_NAME=usuario/legalbertpt-crivoai` e `HF_TOKEN=<token de leitura>` e redeploy. O backend carrega o modelo preguiçosamente na primeira análise (`analysis_provider.py`).
+
+> **Atenção (recursos do Render):** LegalBERT-pt + torch consomem memória; valide se o plano do Web Service tem RAM suficiente para carregar o modelo (o tier gratuito de 512 MB é apertado). O primeiro request após um cold start também baixa os ~435 MB do Hugging Face.
+>
+> **Qualidade:** o checkpoint atual foi treinado com rótulos *weak* (F1-macro ~0.53). Segue experimental até a revisão de rótulos GOLD.
 
 ---
 


### PR DESCRIPTION
## Contexto
Após o merge do #164, o **código** de treino/inferência entrou na dev, mas os **pesos** do modelo fine-tunado não vão no git (gitignored, ~435 MB). O backend (Render Docker) precisa baixar o modelo do Hugging Face em runtime via `MODEL_NAME`. Este PR fecha essa lacuna de deploy.

## O que muda
- **docs(deploy):** nova seção "Publicação do Modelo" em `docs/dev/deploy.md` + env vars `MODEL_NAME` e `HF_TOKEN` no Render.
- **fix(upload):** `upload_model.py` agora cria o repo **privado** por padrão (antes criava público) e resolve o token via `hf auth login` em cache (sem colar token de escrita no shell). Passa em black + flake8 do CI.

## Já feito fora do PR
- Modelo publicado e verificado (privado): `JonathanCarpaneda/legalbertpt-crivoai` (config `num_labels=4`, multi_label; download com auth OK).

## Passo de deploy (Render)
Setar e redeployar:
- `MODEL_NAME=JonathanCarpaneda/legalbertpt-crivoai`
- `HF_TOKEN=<token READ>` (repo privado)

⚠️ Verificar RAM do plano (torch + LegalBERT no free 512 MB pode dar OOM) e latência do 1º request (baixa 435 MB). Qualidade ainda experimental (rótulos weak, F1 ~0.53).