### PR TITLE
Fix/resumo ia endpoint

### DIFF
--- a/backend/app/api/laws.py
+++ b/backend/app/api/laws.py
@@ -54,7 +54,17 @@ async def get_law(law_id: str):
     if law is None:
         raise HTTPException(status_code=404, detail="Submissão não encontrada.")
 
-    return law
+    # Busca a análise mais recente para obter o resumo gerado pela IA, caso exista
+    analysis = None
+    if hasattr(db, "analysis"):
+        analysis = await db.analysis.find_first(
+            where={"lawId": law_id},
+            order={"createdAt": "desc"},
+        )
+
+    law_response = LawResponse.model_validate(law)
+    law_response.summary = analysis.summary if analysis else None
+    return law_response
 
 
 @router_v1.post(

--- a/backend/tests/test_laws.py
+++ b/backend/tests/test_laws.py
@@ -189,15 +189,12 @@ def test_list_law_submissions_com_source_type_invalido_usa_user_upload(monkeypat
 def test_get_law_retorna_resumo_se_existe_analise(monkeypatch):
     """Verifica que o resumo da lei é preenchido se houver análise recente."""
     fake_law_delegate = FakeLawDelegate()
-    
+
     class FakeAnalysisDelegate:
         async def find_first(self, **kwargs):
             return SimpleNamespace(summary="Resumo recuperado.")
-            
-    mock_db = SimpleNamespace(
-        law=fake_law_delegate,
-        analysis=FakeAnalysisDelegate()
-    )
+
+    mock_db = SimpleNamespace(law=fake_law_delegate, analysis=FakeAnalysisDelegate())
     monkeypatch.setattr(laws, "db", mock_db)
 
     response = client.get("/laws/law-123")

--- a/backend/tests/test_laws.py
+++ b/backend/tests/test_laws.py
@@ -184,3 +184,24 @@ def test_list_law_submissions_com_source_type_invalido_usa_user_upload(monkeypat
         "where": {"sourceType": "USER_UPLOAD"},
         "order": {"createdAt": "desc"},
     }
+
+
+def test_get_law_retorna_resumo_se_existe_analise(monkeypatch):
+    """Verifica que o resumo da lei é preenchido se houver análise recente."""
+    fake_law_delegate = FakeLawDelegate()
+    
+    class FakeAnalysisDelegate:
+        async def find_first(self, **kwargs):
+            return SimpleNamespace(summary="Resumo recuperado.")
+            
+    mock_db = SimpleNamespace(
+        law=fake_law_delegate,
+        analysis=FakeAnalysisDelegate()
+    )
+    monkeypatch.setattr(laws, "db", mock_db)
+
+    response = client.get("/laws/law-123")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "law-123"
+    assert response.json()["summary"] == "Resumo recuperado."

--- a/backend/tests/unit/test_laws.py
+++ b/backend/tests/unit/test_laws.py
@@ -189,15 +189,12 @@ def test_list_law_submissions_com_source_type_invalido_usa_user_upload(monkeypat
 def test_get_law_retorna_resumo_se_existe_analise(monkeypatch):
     """Verifica que o resumo da lei é preenchido se houver análise recente."""
     fake_law_delegate = FakeLawDelegate()
-    
+
     class FakeAnalysisDelegate:
         async def find_first(self, **kwargs):
             return SimpleNamespace(summary="Resumo recuperado.")
-            
-    mock_db = SimpleNamespace(
-        law=fake_law_delegate,
-        analysis=FakeAnalysisDelegate()
-    )
+
+    mock_db = SimpleNamespace(law=fake_law_delegate, analysis=FakeAnalysisDelegate())
     monkeypatch.setattr(laws, "db", mock_db)
 
     response = client.get("/laws/law-123")

--- a/backend/tests/unit/test_laws.py
+++ b/backend/tests/unit/test_laws.py
@@ -184,3 +184,24 @@ def test_list_law_submissions_com_source_type_invalido_usa_user_upload(monkeypat
         "where": {"sourceType": "USER_UPLOAD"},
         "order": {"createdAt": "desc"},
     }
+
+
+def test_get_law_retorna_resumo_se_existe_analise(monkeypatch):
+    """Verifica que o resumo da lei é preenchido se houver análise recente."""
+    fake_law_delegate = FakeLawDelegate()
+    
+    class FakeAnalysisDelegate:
+        async def find_first(self, **kwargs):
+            return SimpleNamespace(summary="Resumo recuperado.")
+            
+    mock_db = SimpleNamespace(
+        law=fake_law_delegate,
+        analysis=FakeAnalysisDelegate()
+    )
+    monkeypatch.setattr(laws, "db", mock_db)
+
+    response = client.get("/laws/law-123")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "law-123"
+    assert response.json()["summary"] == "Resumo recuperado."

--- a/frontend/src/app/law/[id]/page.test.tsx
+++ b/frontend/src/app/law/[id]/page.test.tsx
@@ -74,6 +74,7 @@ describe("LawDetailPage - análise de qualidade", () => {
     mockJsonResponse(persistedLaw);
     mockJsonResponse(persistedLaw);
     mockJsonResponse(analysisResponse);
+    mockJsonResponse(persistedLaw);
 
     render(<LawDetailPage />);
 
@@ -84,7 +85,7 @@ describe("LawDetailPage - análise de qualidade", () => {
     expect(screen.getByText("Vagueza - 72%")).toBeInTheDocument();
     expect(screen.getAllByText("Trechos com termos pouco específicos.")[0]).toBeInTheDocument();
 
-    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(4));
 
     const analysisCall = mockFetch.mock.calls.find(
       ([url, options]) =>
@@ -178,6 +179,7 @@ describe("LawDetailPage - Resumo Explicativo por IA", () => {
     mockJsonResponse(persistedLaw);
     mockJsonResponse(lawWithoutSummary);
     mockJsonResponse(analysisResponse);
+    mockJsonResponse(lawWithoutSummary);
 
     render(<LawDetailPage />);
 

--- a/frontend/src/app/law/[id]/page.tsx
+++ b/frontend/src/app/law/[id]/page.tsx
@@ -155,13 +155,13 @@ export default function LawDetailPage() {
 
   useEffect(() => {
     if (!law) return;
+    if (summary) return;
 
     let active = true;
 
     async function fetchSummary() {
       setLoadingSummary(true);
       setErrorSummary("");
-      setSummary(null);
       try {
         const persistedSummary = await getLawSummary(id);
         if (active) {
@@ -187,7 +187,7 @@ export default function LawDetailPage() {
     return () => {
       active = false;
     };
-  }, [law, id]);
+  }, [law, id, analysis, summary]);
 
 
 


### PR DESCRIPTION
## 📝 Descrição

Esta alteração corrige a integração do resumo explicativo gerado por IA na visualização detalhada da lei. Ela implementa a busca do resumo da análise mais recente no endpoint de leitura do backend e adiciona reatividade ao frontend para recarregar o resumo automaticamente assim que o processamento assíncrono do Gemini for concluído no primeiro acesso.

- **Backend**: Atualizada a rota [get_law](file:///c:/Users/pluca/2026-1-Squad07/backend/app/api/laws.py#L50-L70) para buscar a última análise associada à lei (`db.analysis.find_first`) e extrair o `summary` para o [LawResponse](file:///c:/Users/pluca/2026-1-Squad07/backend/app/models/law.py#L31-L48).
- **Testes**: Adicionados novos testes unitários e de integração em [test_laws.py](file:///c:/Users/pluca/2026-1-Squad07/backend/tests/test_laws.py#L187-L208) e [test_laws.py](file:///c:/Users/pluca/2026-1-Squad07/backend/tests/unit/test_laws.py#L187-L208).
- **Frontend**: Ajustado o hook `useEffect` de [page.tsx](file:///c:/Users/pluca/2026-1-Squad07/frontend/src/app/law/%5Bid%5D/page.tsx#L156-L191) para observar o estado de `analysis` e disparar nova busca do resumo reativamente assim que a análise inicial for salva.

## 🏷️ Tipo de alteração
- [ ] ✨ `feat:` Nova funcionalidade
- [x] 🐛 `bugfix:` Correção de um erro
- [ ] ♻️ `refactor:` Refatoração de código (não altera as funcionalidades)
- [ ] 📚 `docs:` Atualização na documentação
- [ ] 🔧 `chore:` Tarefas de manutenção (dependências, configurações, etc.)

## ✅ Checklist de Revisão
- [x] O meu código segue os padrões do nosso Guia Definitivo.
- [x] Realizei uma auto-revisão detalhada do meu próprio código.
- [x] Os meus commits são atômicos e as mensagens seguem o padrão *Conventional Commits*.
- [x] O código não gera novos conflitos de merge (verifiquei a branch base).
- [x] A alteração não introduz novos avisos (warnings) ou erros no terminal.

## 🧪 Testes
- [x] Criei/atualizei testes para esta funcionalidade (se aplicável).
- [x] Testei a funcionalidade localmente e tudo está funcionando perfeitamente.

## 🖼️ Capturas de tela ou Vídeos (Se aplicável)
*(Não aplicável para esta correção de lógica/comunicação de API).*