### PR TITLE
feat(laws): exibe leis do catalogo no dashboard e inclui na estatistica

### DIFF
--- a/backend/app/api/laws.py
+++ b/backend/app/api/laws.py
@@ -41,13 +41,19 @@ async def submit_law(
 
 
 @router.get("", response_model=list[LawListItem])
-async def list_law_submissions(source_type: str = "USER_UPLOAD"):
+async def list_law_submissions(source_type: str = "ALL"):
     """Lista submissoes legislativas enviadas por usuarios ou do catalogo."""
-    if source_type not in ["USER_UPLOAD", "CATALOG"]:
-        source_type = "USER_UPLOAD"
+    # ALL retorna ambos os tipos; qualquer outro valor invalido cai para ALL
+    valid_types = ["USER_UPLOAD", "CATALOG", "ALL"]
+    if source_type not in valid_types:
+        source_type = "ALL"
+
+    where_clause = (
+        {} if source_type == "ALL" else {"sourceType": source_type}
+    )
 
     laws = await db.law.find_many(
-        where={"sourceType": source_type},
+        where=where_clause,
         order={"createdAt": "desc"},
         include={"analyses": True},
     )
@@ -120,9 +126,14 @@ async def analyze_readability(payload: ReadabilityRequest):
     status_code=status.HTTP_200_OK,
 )
 async def get_law_statistics():
-    """Calcula estatísticas de qualidade agregadas a partir do banco."""
+    """Calcula estatisticas de qualidade agregadas a partir do banco.
+
+    Considera leis de qualquer sourceType (USER_UPLOAD e CATALOG), mas
+    apenas as que possuem pelo menos uma analise. Leis sem classificacao
+    nao interferem na media nem nos contadores.
+    """
     laws = await db.law.find_many(
-        where={"sourceType": "USER_UPLOAD"},
+        where={},
         include={"analyses": True},
     )
 

--- a/backend/app/api/laws.py
+++ b/backend/app/api/laws.py
@@ -48,9 +48,7 @@ async def list_law_submissions(source_type: str = "ALL"):
     if source_type not in valid_types:
         source_type = "ALL"
 
-    where_clause = (
-        {} if source_type == "ALL" else {"sourceType": source_type}
-    )
+    where_clause = {} if source_type == "ALL" else {"sourceType": source_type}
 
     laws = await db.law.find_many(
         where=where_clause,

--- a/backend/scripts/ingest_catalog.py
+++ b/backend/scripts/ingest_catalog.py
@@ -75,7 +75,7 @@ async def ingest_catalog(args: argparse.Namespace) -> None:
     only_real: bool = args.only_real
     skip_analysis: bool = args.skip_analysis
 
-    print(f"--- Iniciando Ingestão de Leis do Catálogo ---")
+    print("--- Iniciando Ingestao de Leis do Catalogo ---")
     print(f"Dataset : {dataset_path}")
     print(f"Limite  : {limit or 'sem limite'}")
     print(f"Apenas reais: {only_real}")
@@ -151,11 +151,11 @@ async def ingest_catalog(args: argparse.Namespace) -> None:
 
         if existing is None:
             await db.law.create(data={"id": item["id"], **law_payload})
-            print(f"[{i}/{len(laws_data)}] ✓ Criada : {item['title'][:70]}")
+            print(f"[{i}/{len(laws_data)}] OK Criada : {item['title'][:70]}")
             created_laws += 1
         else:
             await db.law.update(where={"id": item["id"]}, data=law_payload)
-            print(f"[{i}/{len(laws_data)}] ~ Atualizada: {item['title'][:70]}")
+            print(f"[{i}/{len(laws_data)}] -- Atualizada: {item['title'][:70]}")
             updated_laws += 1
 
         if skip_analysis:
@@ -173,7 +173,7 @@ async def ingest_catalog(args: argparse.Namespace) -> None:
             )
             print(
                 f"           Score: {analysis_result['score']:.2f} | "
-                f"Resumo: {'✓' if analysis_result.get('summary') else '✗'}"
+                f"Resumo: {'OK' if analysis_result.get('summary') else 'ERRO'}"
             )
             created_analyses += 1
         except Exception as e:

--- a/backend/tests/test_laws.py
+++ b/backend/tests/test_laws.py
@@ -144,7 +144,7 @@ def test_list_law_submissions_retorna_resumo_das_submissoes(monkeypatch):
 
     assert response.status_code == 200
     assert fake_law_delegate.find_many_args == {
-        "where": {"sourceType": "USER_UPLOAD"},
+        "where": {},
         "order": {"createdAt": "desc"},
         "include": {"analyses": True},
     }
@@ -206,8 +206,8 @@ def test_list_law_submissions_com_source_type_catalog(monkeypatch):
     }
 
 
-def test_list_law_submissions_com_source_type_invalido_usa_user_upload(monkeypatch):
-    """Verifica que valor invalido para source_type faz fallback para USER_UPLOAD."""
+def test_list_law_submissions_com_source_type_invalido_usa_all(monkeypatch):
+    """Verifica que valor invalido para source_type faz fallback para ALL."""
     fake_law_delegate = FakeLawDelegate()
     monkeypatch.setattr(laws, "db", SimpleNamespace(law=fake_law_delegate))
 
@@ -215,7 +215,7 @@ def test_list_law_submissions_com_source_type_invalido_usa_user_upload(monkeypat
 
     assert response.status_code == 200
     assert fake_law_delegate.find_many_args == {
-        "where": {"sourceType": "USER_UPLOAD"},
+        "where": {},
         "order": {"createdAt": "desc"},
         "include": {"analyses": True},
     }

--- a/backend/tests/unit/test_laws.py
+++ b/backend/tests/unit/test_laws.py
@@ -144,7 +144,7 @@ def test_list_law_submissions_retorna_resumo_das_submissoes(monkeypatch):
 
     assert response.status_code == 200
     assert fake_law_delegate.find_many_args == {
-        "where": {"sourceType": "USER_UPLOAD"},
+        "where": {},
         "order": {"createdAt": "desc"},
         "include": {"analyses": True},
     }
@@ -206,8 +206,8 @@ def test_list_law_submissions_com_source_type_catalog(monkeypatch):
     }
 
 
-def test_list_law_submissions_com_source_type_invalido_usa_user_upload(monkeypatch):
-    """Verifica que valor invalido para source_type faz fallback para USER_UPLOAD."""
+def test_list_law_submissions_com_source_type_invalido_usa_all(monkeypatch):
+    """Verifica que valor invalido para source_type faz fallback para ALL."""
     fake_law_delegate = FakeLawDelegate()
     monkeypatch.setattr(laws, "db", SimpleNamespace(law=fake_law_delegate))
 
@@ -215,7 +215,7 @@ def test_list_law_submissions_com_source_type_invalido_usa_user_upload(monkeypat
 
     assert response.status_code == 200
     assert fake_law_delegate.find_many_args == {
-        "where": {"sourceType": "USER_UPLOAD"},
+        "where": {},
         "order": {"createdAt": "desc"},
         "include": {"analyses": True},
     }

--- a/frontend/src/lib/api/laws.ts
+++ b/frontend/src/lib/api/laws.ts
@@ -62,7 +62,7 @@ export function submitLaw(submission: LawSubmission, token?: string | null) {
   });
 }
 
-export function listLawSubmissions(sourceType: string = "USER_UPLOAD") {
+export function listLawSubmissions(sourceType: string = "ALL") {
   return apiRequest<LawSubmissionListItem[]>(
     `/laws?source_type=${encodeURIComponent(sourceType)}`,
   );


### PR DESCRIPTION
## 📝 Descrição

Exibe as leis do catálogo (Câmara dos Deputados) no dashboard e na busca, junto com as submissões de usuários. Leis sem análise aparecem na listagem mas não interferem nas estatísticas de qualidade — apenas leis classificadas contribuem para a média de score, contagem de analisadas e leis críticas.

**Alterações realizadas:**
- `GET /laws` aceita novo valor `source_type=ALL` (novo padrão), retornando `USER_UPLOAD` + `CATALOG` juntos. Os filtros individuais `USER_UPLOAD` e `CATALOG` continuam funcionando normalmente.
- `GET /api/v1/laws/statistics` passou a considerar leis de qualquer `sourceType`, mantendo a regra de contar apenas leis que possuem pelo menos uma análise — leis do catálogo sem classificação não distorcem a média.
- Frontend: `listLawSubmissions()` usa `ALL` por padrão, exibindo as 550 leis reais da Câmara junto com as submissões de usuários no dashboard e na página de busca.

## 🏷️ Tipo de alteração
- [x] ✨ `feat:` Nova funcionalidade
- [ ] 🐛 `bugfix:` Correção de um erro
- [ ] ♻️ `refactor:` Refatoração de código (não altera as funcionalidades)
- [ ] 📚 `docs:` Atualização na documentação
- [ ] 🔧 `chore:` Tarefas de manutenção (dependências, configurações, etc.)

## ✅ Checklist de Revisão
- [x] O meu código segue os padrões do nosso Guia Definitivo.
- [x] Realizei uma auto-revisão detalhada do meu próprio código.
- [x] Os meus commits são atômicos e as mensagens seguem o padrão *Conventional Commits*.
- [x] O código não gera novos conflitos de merge (verifiquei a branch base).
- [x] A alteração não introduz novos avisos (warnings) ou erros no terminal.

## 🧪 Testes
- [x] Criei/atualizei testes para esta funcionalidade (se aplicável).
  - 29/29 testes de `laws` passando após atualização dos casos que verificavam o comportamento anterior (`USER_UPLOAD` como fallback → agora `ALL`).
- [ ] Testei a funcionalidade localmente e tudo está funcionando perfeitamente.
  - ⚠️ Requer validação em produção após o deploy: verificar se as 550 leis da Câmara aparecem no dashboard e se leis sem análise não alteram as estatísticas de qualidade.